### PR TITLE
Version up, to sync PyPI and GH

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pandas-checks"
-version = "0.2.0"
+version = "0.2.1"
 description = "Non-invasive health checks for Pandas method chains"
 authors = ["Chad Parmet <cparmet@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
Aligns PyPI and GH versions of the package

The last PR for version 0.2.0 by mistake included one commit that wasn't on PyPI 0.2.0. Now, 0.2.1 versions are aligned on both sources.

Pull request checklist
- [x] PR describes the changes proposed
- [x] Tests were checked for updates
- [x] Tests pass with `nox`
- [x] Docstrings and docs were checked for updates
