### PR TITLE
Fix argument name in docstrings

### DIFF
--- a/pandas_checks/DataFrameChecks.py
+++ b/pandas_checks/DataFrameChecks.py
@@ -581,7 +581,7 @@ class DataFrameChecks:
         """Tests whether Dataframe or subset of columns meets type assumption. Optionally raises an exception. Does not modify the DataFrame itself.
 
         Args:
-            type: The required variable type
+            dtype: The required variable type
             subset: Optional, which column or columns to check the condition against. `
             pass_message: Message to display if the condition passes.
             fail_message: Message to display if the condition fails.

--- a/pandas_checks/SeriesChecks.py
+++ b/pandas_checks/SeriesChecks.py
@@ -545,7 +545,7 @@ class SeriesChecks:
         """Tests whether Series meets type assumption. Optionally raises an exception. Does not modify the Series itself.
 
         Args:
-            type: The required variable type
+            dtype: The required variable type
 
             pass_message: Message to display if the condition passes.
             fail_message: Message to display if the condition fails.


### PR DESCRIPTION
Fix an outdated argument name in docstrings

Pull request checklist
- [x] PR describes the changes proposed
- [x] Tests were checked for updates
- [x] Tests pass with `nox`
- [x] Docstrings and docs were checked for updates
