### PR TITLE
Align docstrings on units for timer

### DIFF
--- a/pandas_checks/DataFrameChecks.py
+++ b/pandas_checks/DataFrameChecks.py
@@ -1163,10 +1163,10 @@ class DataFrameChecks:
         Args:
             start_time: The index time when the stopwatch started, which comes from the Pandas Checks start_timer()
             lead_in: Optional text to print before the elapsed time.
-            units: The units in which to display the elapsed time. Can be "auto", "seconds", "minutes", or "hours".
+            units: The units in which to display the elapsed time. Allowed values: "auto", "milliseconds", "seconds", "minutes", "hours" or shorthands "ms", "s", "m", "h".
 
         Raises:
-            ValueError: If `units` is not one of "auto", "seconds", "minutes", or "hours".
+            ValueError: If `units` is not one of allowed values.
 
         Returns:
             The original DataFrame, unchanged.

--- a/pandas_checks/SeriesChecks.py
+++ b/pandas_checks/SeriesChecks.py
@@ -967,10 +967,10 @@ class SeriesChecks:
         Args:
         start_time: The index time when the stopwatch started, which comes from the Pandas Checks start_timer()
         lead_in: Optional text to print before the elapsed time.
-        units: The units in which to display the elapsed time. Can be "auto", "seconds", "minutes", or "hours".
+        units: The units in which to display the elapsed time. Allowed values: "auto", "milliseconds", "seconds", "minutes", "hours" or shorthands "ms", "s", "m", "h".
 
         Raises:
-            ValueError: If `units` is not one of "auto", "seconds", "minutes", or "hours".
+            ValueError: If `units` is not one of allowed values.
 
         Returns:
             The original Series, unchanged.

--- a/pandas_checks/timer.py
+++ b/pandas_checks/timer.py
@@ -40,16 +40,13 @@ def print_time_elapsed(
     Args:
         start_time: The index time when the stopwatch started, which comes from the Pandas Checks start_timer()
         lead_in: Optional text to print before the elapsed time.
-        units: The units in which to display the elapsed time. Accepted values:
-            - "auto"
-            - "milliseconds", "seconds", "minutes", "hours"
-            - "ms", "s", "m", "h"
+        units: The units in which to display the elapsed time. Allowed values: "auto", "milliseconds", "seconds", "minutes", "hours" or shorthands "ms", "s", "m", "h"
 
     Returns:
         None
 
     Raises:
-        ValueError: If `units` is not one of expected time units
+        ValueError: If `units` is not one of allowed values.
 
     Note:
         If you change the default values for this function's argument,


### PR DESCRIPTION
Update stale description of allowed time units in `timer` functions

Pull request checklist
- [x] PR describes the changes proposed
- [x] Tests were checked for updates
- [x] Tests pass with `nox`
- [x] Docstrings and docs were checked for updates
