### PR TITLE
Fix leftover typo in docstring example usage

### DIFF
--- a/pandas_checks/DataFrameChecks.py
+++ b/pandas_checks/DataFrameChecks.py
@@ -128,7 +128,7 @@ class DataFrameChecks:
 
                     # Or show a message if it passes, and raise a specific exception (ValueError) if it fails.
                     .check.assert_data(
-                        lambda df: s.shape[0]>1,
+                        lambda df: s.shape[0]>0,
                         fail_message="FYI DataFrame has 0 rows",
                         pass_message="DataFrame has at least 1 row!",
                         exception_to_raise=ValueError,


### PR DESCRIPTION
Only docs changed. Whoops, missed one typo during #41 

Pull request checklist
- [X] PR describes the changes proposed
- [n/a] Tests were checked for updates
- [n/a] Tests pass with `nox`
- [X] Docstrings and docs were checked for updates
