### PR TITLE
Allow df.check.nunique() to accept multiple columns

### DIFF
--- a/pandas_checks/DataFrameChecks.py
+++ b/pandas_checks/DataFrameChecks.py
@@ -1474,12 +1474,12 @@ class DataFrameChecks:
 
     def nunique(
         self,
-        column: str,
+        columns: Union[str, list, None] = None,
         fn: Callable = lambda df: df,
         check_name: Union[str, None] = None,
         **kwargs: Any,
     ) -> pd.DataFrame:
-        """Displays the number of unique rows in a single column, without modifying the DataFrame itself.
+        """Displays the number of unique rows, considering a single column or uniqueness across multiple columns, without modifying the DataFrame itself.
 
         See Pandas docs for [nunique()](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.nunique.html) for additional usage information, including more configuration options you can pass to this Pandas Checks method.
 
@@ -1487,12 +1487,12 @@ class DataFrameChecks:
             ```python
                 (
                     iris
-                    .check.nunique(column="sepal_width")
+                    .check.nunique(columns="sepal_width")
                 )
             ```
 
         Args:
-            column: The name of a column to count uniques in. Applied after fn.
+            columns: The name of a column, or a list of columns, to consider when counting the number of unique rows. Pass `None` to consider all columns. Applied after fn.
             fn: An optional lambda function to apply to the DataFrame before running Pandas nunique(). Example: `lambda df: df.shape[0]>10`. Applied before subset.
             check_name: An optional name for the check, to be printed as preface to the result.
             **kwargs: Optional, additional arguments that are accepted by Pandas nunique() method.
@@ -1502,15 +1502,33 @@ class DataFrameChecks:
         """
 
         if get_mode()["enable_checks"]:
-            (
-                # Apply fn, then filter to `column`, pass to SeriesChecks.check.nunique()
-                _apply_modifications(self._obj, fn=fn, subset=column)
-                .check.nunique(
-                    fn=lambda df: df,  # Identity function
-                    check_name=check_name,
-                    **kwargs,
-                )
-            )  # fmt: skip
+            # Ensure columns_clean is a list
+            columns_clean = (
+                [columns] if (isinstance(columns, str) or not columns) else columns
+            )
+            if len(columns_clean) == 0:
+                # When columns=None, consider all columns
+                columns_clean = self._obj.columns.tolist()
+            if len(columns_clean) == 1:
+                (
+                    # Apply fn, then filter to single column, pass to SeriesChecks.check.nunique()
+                    _apply_modifications(self._obj, fn=fn, subset=columns_clean[0])
+                    .check.nunique(
+                        fn=lambda df: df,  # Identity function
+                        check_name=check_name,
+                        **kwargs,
+                    )
+                )  # fmt: skip
+
+            else:
+                # Calculate the number of unique combinations of values in multiple columns
+                if not check_name:
+                    check_name = f"Unique rows in {columns_clean}"
+                (
+                    _apply_modifications(self._obj, fn=fn)
+                    .drop_duplicates(columns_clean)
+                    .check.nrows(check_name=check_name)
+                )  # fmt: skip
         return self._obj
 
     def plot(

--- a/pandas_checks/DataFrameChecks.py
+++ b/pandas_checks/DataFrameChecks.py
@@ -1506,13 +1506,16 @@ class DataFrameChecks:
                 raise AttributeError(
                     f"check.nunique() received unexpected dtype {type(columns)} for `columns`. Expected str, list, or None."
                 )
-            # Ensure columns_clean is a list
-            columns_clean = (
-                [columns] if (isinstance(columns, str) or columns is None) else columns
-            )
-            if len(columns_clean) == 0:
-                # When columns=None, consider all columns
-                columns_clean = self._obj.columns.tolist()
+
+            # Standardize columns into a list
+            if isinstance(columns, str):
+                columns_clean = [columns]
+            elif columns is None:
+                columns_clean = []
+            else:
+                # Converts tuples and sets to lists too
+                columns_clean = list(columns)
+
             if len(columns_clean) == 1:
                 (
                     # Apply fn, then filter to single column, pass to SeriesChecks.check.nunique()
@@ -1530,7 +1533,7 @@ class DataFrameChecks:
                     check_name = f"Unique rows in {columns_clean}"
                 (
                     _apply_modifications(self._obj, fn=fn)
-                    .drop_duplicates(columns_clean)
+                    .drop_duplicates(columns_clean if len(columns_clean)>0 else None)
                     .check.nrows(check_name=check_name)
                 )  # fmt: skip
         return self._obj

--- a/pandas_checks/DataFrameChecks.py
+++ b/pandas_checks/DataFrameChecks.py
@@ -1502,6 +1502,10 @@ class DataFrameChecks:
         """
 
         if get_mode()["enable_checks"]:
+            if not isinstance(columns, str | list | None):
+                raise AttributeError(
+                    f"check.nunique() received unexpected dtype {type(columns)} for `columns`. Expected str, list, or None."
+                )
             # Ensure columns_clean is a list
             columns_clean = (
                 [columns] if (isinstance(columns, str) or columns is None) else columns

--- a/pandas_checks/DataFrameChecks.py
+++ b/pandas_checks/DataFrameChecks.py
@@ -1504,7 +1504,7 @@ class DataFrameChecks:
         if get_mode()["enable_checks"]:
             # Ensure columns_clean is a list
             columns_clean = (
-                [columns] if (isinstance(columns, str) or not columns) else columns
+                [columns] if (isinstance(columns, str) or columns is None) else columns
             )
             if len(columns_clean) == 0:
                 # When columns=None, consider all columns

--- a/pandas_checks/DataFrameChecks.py
+++ b/pandas_checks/DataFrameChecks.py
@@ -1503,7 +1503,7 @@ class DataFrameChecks:
 
         if get_mode()["enable_checks"]:
             if not isinstance(columns, str | int | list | None):
-                raise AttributeError(
+                raise ValueError(
                     f"check.nunique() received unexpected dtype {type(columns)} for `columns`. Expected str, int, list, or None."
                 )
 

--- a/pandas_checks/DataFrameChecks.py
+++ b/pandas_checks/DataFrameChecks.py
@@ -1474,7 +1474,7 @@ class DataFrameChecks:
 
     def nunique(
         self,
-        columns: Union[str, list, None] = None,
+        columns: Union[str, int, list, None] = None,
         fn: Callable = lambda df: df,
         check_name: Union[str, None] = None,
         **kwargs: Any,
@@ -1502,40 +1502,29 @@ class DataFrameChecks:
         """
 
         if get_mode()["enable_checks"]:
-            if not isinstance(columns, str | list | None):
+            if not isinstance(columns, str | int | list | None):
                 raise AttributeError(
-                    f"check.nunique() received unexpected dtype {type(columns)} for `columns`. Expected str, list, or None."
+                    f"check.nunique() received unexpected dtype {type(columns)} for `columns`. Expected str, int, list, or None."
                 )
 
-            # Standardize columns into a list
-            if isinstance(columns, str):
+            columns_clean: list | None
+            if isinstance(columns, str | int):
                 columns_clean = [columns]
-            elif columns is None:
-                columns_clean = []
             else:
-                # Converts tuples and sets to lists too
-                columns_clean = list(columns)
+                # Includes columns=None
+                columns_clean = columns
 
-            if len(columns_clean) == 1:
-                (
-                    # Apply fn, then filter to single column, pass to SeriesChecks.check.nunique()
-                    _apply_modifications(self._obj, fn=fn, subset=columns_clean[0])
-                    .check.nunique(
-                        fn=lambda df: df,  # Identity function
-                        check_name=check_name,
-                        **kwargs,
-                    )
-                )  # fmt: skip
-
-            else:
-                # Calculate the number of unique combinations of values in multiple columns
-                if not check_name:
-                    check_name = f"Unique rows in {columns_clean}"
-                (
-                    _apply_modifications(self._obj, fn=fn)
-                    .drop_duplicates(columns_clean if len(columns_clean)>0 else None)
-                    .check.nrows(check_name=check_name)
-                )  # fmt: skip
+            if not check_name:
+                check_name = (
+                    f"Unique rows in {columns_clean}"
+                    if columns_clean is not None
+                    else "Unique rows"
+                )
+            (
+                _apply_modifications(self._obj, fn=fn)
+                .drop_duplicates(columns_clean)
+                .check.nrows(check_name=check_name)
+            )  # fmt: skip
         return self._obj
 
     def plot(

--- a/pandas_checks/run_checks.py
+++ b/pandas_checks/run_checks.py
@@ -20,6 +20,7 @@ def _apply_modifications(
 
     Returns:
         Modified and optionally subsetted data object.  If all arguments are defaults, data is returned unchanged.
+        If subset is a string and data is a DataFrame, will return a Series. If subset is a list, even if one item, will still return a DataFrame
     """
     if not callable(fn):
         raise TypeError(

--- a/tests/cases_dataframechecks.py
+++ b/tests/cases_dataframechecks.py
@@ -206,10 +206,10 @@ def method_nrows():
 
 def method_nunique():
     return lambda df, args: df.check.nunique(
-        # For multiindex dataframes like brain_networks.csv, "first_num_col" returns a tuple that breaks nunique(). We'll just take the first column item in that case, since this test is only used to ensure that .check.nunique() doesn't mutate the original DF.
+        # For multiindex dataframes like brain_networks.csv, "first_num_col" returns a tuple that breaks nunique(). We'll just take all the columns in that case, since this test is only used to ensure that .check.nunique() doesn't mutate the original DF.
         columns=args["first_num_col"]
         if not isinstance(args["first_num_col"], tuple)
-        else args["first_num_col"][0],
+        else None,
         fn=lambda df: df.dropna(),
         check_name="Test",
         dropna=False,

--- a/tests/cases_dataframechecks.py
+++ b/tests/cases_dataframechecks.py
@@ -2,6 +2,7 @@
 that they don't change the actual dataframe
 in the method chain """
 
+
 import pandas_checks as pdc
 
 
@@ -205,7 +206,10 @@ def method_nrows():
 
 def method_nunique():
     return lambda df, args: df.check.nunique(
-        columns=args["first_num_col"],
+        # For multiindex dataframes like brain_networks.csv, "first_num_col" returns a tuple that breaks nunique(). We'll just take the first column item in that case, since this test is only used to ensure that .check.nunique() doesn't mutate the original DF.
+        columns=args["first_num_col"]
+        if not isinstance(args["first_num_col"], tuple)
+        else args["first_num_col"][0],
         fn=lambda df: df.dropna(),
         check_name="Test",
         dropna=False,

--- a/tests/cases_dataframechecks.py
+++ b/tests/cases_dataframechecks.py
@@ -205,7 +205,7 @@ def method_nrows():
 
 def method_nunique():
     return lambda df, args: df.check.nunique(
-        column=args["first_num_col"],
+        columns=args["first_num_col"],
         fn=lambda df: df.dropna(),
         check_name="Test",
         dropna=False,

--- a/tests/test_dataframechecks.py
+++ b/tests/test_dataframechecks.py
@@ -202,7 +202,20 @@ def test_DataFrameChecks_nrows(iris, capsys):
 
 def test_DataFrameChecks_nunique(iris, capsys):
     iris.check.nunique(
-        fn=lambda df: df.assign(C=55), check_name="Test", column="species", dropna=False
+        fn=lambda df: df.assign(C=55),
+        check_name="Test",
+        columns="species",
+        dropna=False,
+    )
+    assert capsys.readouterr().out == "\nTest: 3\n"
+
+
+def test_DataFrameChecks_nunique_multiple_columns(iris, capsys):
+    iris.check.nunique(
+        fn=lambda df: df.assign(C=55),
+        check_name="Test",
+        columns=["C", "species"],
+        dropna=False,
     )
     assert capsys.readouterr().out == "\nTest: 3\n"
 

--- a/tests/test_dataframechecks.py
+++ b/tests/test_dataframechecks.py
@@ -220,6 +220,16 @@ def test_DataFrameChecks_nunique_multiple_columns(iris, capsys):
     assert capsys.readouterr().out == "\nTest: 3\n"
 
 
+def test_DataFrameChecks_nunique_columns_is_None(iris, capsys):
+    iris.check.nunique(
+        fn=lambda df: df.assign(C=55),
+        check_name="Test",
+        columns=None,
+        dropna=False,
+    )
+    assert capsys.readouterr().out == "\nTest: 149\n"
+
+
 def test_DataFrameChecks_plot_no_terminal_display(iris, capsys):
     iris.check.plot(subset=["sepal_width", "petal_length"])
     assert capsys.readouterr().out == ""


### PR DESCRIPTION
Partially addresses #60 

For Dataframe `check.nunique()`:
* Change `column` argument to `columns`
* When `columns` is a str, behavior is unchanged: run Pandas `nunique()` on that single Series
* When `columns` is a list, count the number of unique rows considering the subset of `columns`
* When `columns` is None (default), consider the number of unique rows considering all columns 

Pull request checklist
- [X] PR describes the changes proposed
- [X] Tests were checked for updates
- [X] Tests pass with `nox`
- [X] Docstrings and docs were checked for updates
