### PR TITLE
Allow df.check.nunique() to accept multiple columns (take 2)

### DIFF
--- a/pandas_checks/DataFrameChecks.py
+++ b/pandas_checks/DataFrameChecks.py
@@ -1474,6 +1474,7 @@ class DataFrameChecks:
 
     def nunique(
         self,
+        column: Union[str, None] = None,
         subset: Union[str, List, None] = None,
         across_columns: bool = False,
         fn: Callable = lambda df: df,
@@ -1483,6 +1484,7 @@ class DataFrameChecks:
         """Displays the number of unique values in a Series or unique combinations of rows in a DataFrame, without modifying the DataFrame itself.
 
         Note:
+            * Must pass either column or subset
             * When across_columns=False, we use the standard Pandas nunique() methods. In those methods, dropna=True by default. You can change this by passing dropna=False
                 - See Pandas docs for [nunique() DataFrame](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.nunique.html) or [nunique() Series](https://pandas.pydata.org/docs/reference/api/pandas.Series.nunique.html) for additional usage information, including more options you can pass to this Pandas Checks method.
 
@@ -1490,7 +1492,7 @@ class DataFrameChecks:
             ```python
                 (
                     iris
-                    .check.nunique(subset="sepal_width") # Unique values of sepal_width (standard Pandas Series.nunique())
+                    .check.nunique(column="sepal_width") # Unique values of sepal_width (standard Pandas Series.nunique())
                     .check.nunique(subset=["petal_width, "sepal_width"]) # Unique values in each column separately (standard Pandas DataFrame.nunique())
                     .check.nunique(subset=["petal_width, "sepal_width"], across_columns=True) # Unique combinations of values
 
@@ -1498,6 +1500,7 @@ class DataFrameChecks:
             ```
 
         Args:
+            column: The optional name of a column to count uniques in. Applied after fn.
             subset: The optional name of a column or columns to count uniques in. If None, will include all columns. Applied after fn.
             across_columns: When dataframe has multiple columns (after applying subset), whether we should
                 - count the unique values in each column separately (False), the standard Pandas DataFrame nunique()
@@ -1511,6 +1514,15 @@ class DataFrameChecks:
         """
 
         if get_mode()["enable_checks"]:
+            if column is not None and subset is not None:
+                raise AttributeError(
+                    ".check.nunique() accepts either a column or subset but not both"
+                )
+
+            # Coalesce subset and column
+            if column:
+                subset = column
+
             data_modified = _apply_modifications(self._obj, fn=fn, subset=subset)
 
             if not check_name:
@@ -1535,7 +1547,7 @@ class DataFrameChecks:
                 # Count the number of unique rows considering values in multiple columns
                 if "dropna" in kwargs:
                     raise AttributeError(
-                        "check.nunique() does not support dropna when across_columns=True"
+                        "DataFrame check.nunique() does not support dropna when across_columns=True"
                     )
                 (
                     data_modified

--- a/pandas_checks/DataFrameChecks.py
+++ b/pandas_checks/DataFrameChecks.py
@@ -1484,7 +1484,6 @@ class DataFrameChecks:
         """Displays the number of unique values in a Series or unique combinations of rows in a DataFrame, without modifying the DataFrame itself.
 
         Note:
-            * Must pass either column or subset
             * When across_columns=False, we use the standard Pandas nunique() methods. In those methods, dropna=True by default. You can change this by passing dropna=False
                 - See Pandas docs for [nunique() DataFrame](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.nunique.html) or [nunique() Series](https://pandas.pydata.org/docs/reference/api/pandas.Series.nunique.html) for additional usage information, including more options you can pass to this Pandas Checks method.
 
@@ -1501,7 +1500,7 @@ class DataFrameChecks:
 
         Args:
             column: The optional name of a column to count uniques in. Applied after fn.
-            subset: The optional name of a column or columns to count uniques in. If None, will include all columns. Applied after fn.
+            subset: The optional name of a column or columns to count uniques in. If None, and column is None, will include all columns. Applied after fn.
             across_columns: When dataframe has multiple columns (after applying subset), whether we should
                 - count the unique values in each column separately (False), the standard Pandas DataFrame nunique()
                 - count the unique combinations of rows across those columns (True) or

--- a/pandas_checks/DataFrameChecks.py
+++ b/pandas_checks/DataFrameChecks.py
@@ -1474,43 +1474,74 @@ class DataFrameChecks:
 
     def nunique(
         self,
-        column: str,
+        subset: Union[str, List, None] = None,
+        across_columns: bool = False,
         fn: Callable = lambda df: df,
         check_name: Union[str, None] = None,
         **kwargs: Any,
     ) -> pd.DataFrame:
-        """Displays the number of unique rows in a single column, without modifying the DataFrame itself.
+        """Displays the number of unique values in a Series or unique combinations of rows in a DataFrame, without modifying the DataFrame itself.
 
-        See Pandas docs for [nunique()](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.nunique.html) for additional usage information, including more configuration options you can pass to this Pandas Checks method.
+        Note:
+            * When across_columns=False, we use the standard Pandas nunique() methods. In those methods, dropna=True by default. You can change this by passing dropna=False
+                - See Pandas docs for [nunique() DataFrame](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.nunique.html) or [nunique() Series](https://pandas.pydata.org/docs/reference/api/pandas.Series.nunique.html) for additional usage information, including more options you can pass to this Pandas Checks method.
 
         Example:
             ```python
                 (
                     iris
-                    .check.nunique(column="sepal_width")
+                    .check.nunique(subset="sepal_width") # Unique values of sepal_width (standard Pandas Series.nunique())
+                    .check.nunique(subset=["petal_width, "sepal_width"]) # Unique values in each column separately (standard Pandas DataFrame.nunique())
+                    .check.nunique(subset=["petal_width, "sepal_width"], across_columns=True) # Unique combinations of values
+
                 )
             ```
 
         Args:
-            column: The name of a column to count uniques in. Applied after fn.
+            subset: The optional name of a column or columns to count uniques in. If None, will include all columns. Applied after fn.
+            across_columns: When dataframe has multiple columns (after applying subset), whether we should
+                - count the unique values in each column separately (False), the standard Pandas DataFrame nunique()
+                - count the unique combinations of rows across those columns (True) or
             fn: An optional lambda function to apply to the DataFrame before running Pandas nunique(). Example: `lambda df: df.shape[0]>10`. Applied before subset.
             check_name: An optional name for the check, to be printed as preface to the result.
-            **kwargs: Optional, additional arguments that are accepted by Pandas nunique() method.
+            **kwargs: Optional, additional arguments that are accepted by Pandas nunique() method(s)
 
         Returns:
             The original DataFrame, unchanged.
         """
 
         if get_mode()["enable_checks"]:
-            (
-                # Apply fn, then filter to `column`, pass to SeriesChecks.check.nunique()
-                _apply_modifications(self._obj, fn=fn, subset=column)
-                .check.nunique(
-                    fn=lambda df: df,  # Identity function
+            data_modified = _apply_modifications(self._obj, fn=fn, subset=subset)
+
+            if not check_name:
+                if subset:
+                    if isinstance(subset, str):
+                        check_name = f"🌟 Unique values in '{subset}'"
+                    else:
+                        check_name = f"🌟 Unique values in {subset}"
+                else:
+                    check_name = "🌟 Unique values"
+
+            if not across_columns:
+                # Run standard Pandas nunique()
+                # Note: This may run DataFrame.nunique() or Series.nunique(), depending if subset is a column or multiple columns
+                _check_data(
+                    data_modified,
+                    check_fn=lambda data: data.nunique(**kwargs),
+                    modify_fn=fn,
                     check_name=check_name,
-                    **kwargs,
-                )
-            )  # fmt: skip
+                )  # fmt: skip
+            else:
+                # Count the number of unique rows considering values in multiple columns
+                if "dropna" in kwargs:
+                    raise AttributeError(
+                        "check.nunique() does not support dropna when across_columns=True"
+                    )
+                (
+                    data_modified
+                    .drop_duplicates()
+                    .check.nrows(check_name=check_name)
+                )  # fmt: skip
         return self._obj
 
     def plot(

--- a/pandas_checks/DataFrameChecks.py
+++ b/pandas_checks/DataFrameChecks.py
@@ -1528,10 +1528,16 @@ class DataFrameChecks:
                 if subset:
                     if isinstance(subset, str):
                         check_name = f"🌟 Unique values in '{subset}'"
+                    elif across_columns:
+                        check_name = f"🌟 Unique rows across {subset}"
                     else:
                         check_name = f"🌟 Unique values in {subset}"
                 else:
-                    check_name = "🌟 Unique values"
+                    if across_columns:
+                        check_name = "🌟 Unique rows across all columns"
+                    else:
+                        check_name = "🌟 Unique values"
+
 
             if not across_columns:
                 # Run standard Pandas nunique()

--- a/tests/cases_dataframechecks.py
+++ b/tests/cases_dataframechecks.py
@@ -205,7 +205,7 @@ def method_nrows():
 
 def method_nunique():
     return lambda df, args: df.check.nunique(
-        column=args["first_num_col"],
+        subset=args["first_num_col"],
         fn=lambda df: df.dropna(),
         check_name="Test",
         dropna=False,

--- a/tests/test_dataframechecks.py
+++ b/tests/test_dataframechecks.py
@@ -202,9 +202,19 @@ def test_DataFrameChecks_nrows(iris, capsys):
 
 def test_DataFrameChecks_nunique(iris, capsys):
     iris.check.nunique(
-        fn=lambda df: df.assign(C=55), check_name="Test", column="species", dropna=False
+        fn=lambda df: df, check_name="Test", subset="species", dropna=False
     )
     assert capsys.readouterr().out == "\nTest: 3\n"
+
+
+def test_DataFrameChecks_nunique_across_columns(iris, capsys):
+    iris.check.nunique(
+        fn=lambda df: df.assign(C=55),
+        check_name="Test",
+        subset=["species", "petal_width"],
+        across_columns=True,
+    )
+    assert capsys.readouterr().out == "\nTest: 27\n"
 
 
 def test_DataFrameChecks_plot_no_terminal_display(iris, capsys):

--- a/tests/test_dataframechecks.py
+++ b/tests/test_dataframechecks.py
@@ -200,7 +200,14 @@ def test_DataFrameChecks_nrows(iris, capsys):
     assert capsys.readouterr().out == "\nTest: 150\n"
 
 
-def test_DataFrameChecks_nunique(iris, capsys):
+def test_DataFrameChecks_nunique_one_column(iris, capsys):
+    iris.check.nunique(
+        fn=lambda df: df, check_name="Test", column="species", dropna=False
+    )
+    assert capsys.readouterr().out == "\nTest: 3\n"
+
+
+def test_DataFrameChecks_nunique_subset_one_column(iris, capsys):
     iris.check.nunique(
         fn=lambda df: df, check_name="Test", subset="species", dropna=False
     )


### PR DESCRIPTION
Partially addresses #60 

Adds ability to pass an entire DataFrame to `.check.nunique()`, instead of requiring a single `column` argument. Adds `subset` argument as an alternative; keeping `column` for backwards compatibility

By default, runs the normal Pandas DataFrame `nunique()`, reporting count of unique values in each column separately.

If you set `across_columns=True`, it will instead count the number of rows with unique combinations of values in the DataFrame's columns (after selecting `subset`, if passed)

Pull request checklist
- [X] PR describes the changes proposed
- [X] Tests were checked for updates
- [X] Tests pass with `nox`
- [X] Docstrings and docs were checked for updates
