### PR TITLE
Msg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__
 *.parquet
 *.feather
 *.pkl
+*.log
 archive/*
 dev.ipynb
 dev_script.py

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ iris_processed = (
     iris
     .dropna()
     .check.assert_positive(subset=["petal_length", "sepal_length"]) # 🐼🩺 Validate assumptions
-    .check.hist(column='petal_length') # 🐼🩺 Plot the distribution of a column after cleaning
+    .check.hist('petal_length') # 🐼🩺 Plot the distribution of a column after cleaning
 
     .query("species=='setosa'")
     .check.head(3)  # 🐼🩺 Display the first few rows after more cleaning

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -166,14 +166,14 @@ You can use Pandas Checks methods like the regular Pandas methods. They accept t
 * `.check.plot(kind="scatter", x="sepal_width", y="sepal_length")`
 
 Also, most Pandas Checks methods accept 3 additional arguments:
-1. `check_name`: text to display before the result of the check
+1. `msg`: text to display before the result of the check
 2. `fn`: a lambda function that modifies the data displayed by the check
 3. `subset`: limit a check to certain columns
 
 ```python
 (
     iris
-    .check.value_counts(column='species', check_name="Varieties after data cleaning")
+    .check.value_counts(column='species', msg="Varieties after data cleaning")
     .assign(species=lambda df: df["species"].str.upper()) # Do your regular Pandas data processing, like upper-casing the values in one column
     .check.head(n=2, fn=lambda df: df["petal_width"]*2) # Modify the data that gets displayed in the check only
     .check.describe(subset=['sepal_width', 'sepal_length'])  # Only apply the check to certain columns

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -64,7 +64,7 @@ You can add some `.check` steps.
     .check.assert_positive(subset=["petal_length", "sepal_length"])
 
     # Plot the distribution of a column after cleaning
-    .check.hist(column='petal_length') 
+    .check.hist('petal_length') 
 
     .query("species=='setosa'")
     

--- a/pandas_checks/DataFrameChecks.py
+++ b/pandas_checks/DataFrameChecks.py
@@ -949,7 +949,7 @@ class DataFrameChecks:
         Args:
             fn: An optional lambda function to apply to the DataFrame before printing columns. Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before printing their names. Applied after fn.
-            msg: An optional name for the check to preface the result with.
+            msg: Optionally customize the text displayed before the result of the check.
 
         Returns:
             The original DataFrame, unchanged.
@@ -985,7 +985,7 @@ class DataFrameChecks:
         Args:
             fn: An optional lambda function to apply to the DataFrame before running Pandas describe(). Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before running Pandas describe(). Applied after fn.
-            msg: An optional name for the check to preface the result with.
+            msg: Optionally customize the text displayed before the result of the check.
             **kwargs: Optional, additional arguments that are accepted by Pandas describe() method.
 
         Returns:
@@ -1041,7 +1041,7 @@ class DataFrameChecks:
         Args:
             fn: An optional lambda function to apply to the DataFrame before running Pandas dtypes. Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before running Pandas .dtypes. Applied after fn.
-            msg: An optional name for the check to preface the result with.
+            msg: Optionally customize the text displayed before the result of the check.
 
         Returns:
             The original DataFrame, unchanged.
@@ -1098,7 +1098,7 @@ class DataFrameChecks:
         Args:
             fn: A lambda function to apply to the DataFrame. Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before running Pandas describe(). Applied after fn.
-            msg: An optional name for the check to preface the result with.
+            msg: Optionally customize the text displayed before the result of the check.
 
         Returns:
             The original DataFrame, unchanged.
@@ -1121,7 +1121,7 @@ class DataFrameChecks:
             ```
 
         Args:
-            msg: An optional name for the check. Will be used as a preface the printed result.
+            msg: Optionally customize the text displayed before the result of the check.
 
         Returns:
             The original DataFrame, unchanged.
@@ -1152,7 +1152,7 @@ class DataFrameChecks:
             n: The number of rows to display.
             fn: An optional lambda function to apply to the DataFrame before running Pandas head(). Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before running Pandas head(). Applied after fn.
-            msg: An optional name for the check, to be printed as preface to the result.
+            msg: Optionally customize the text displayed before the result of the check.
 
         Returns:
             The original DataFrame, unchanged.
@@ -1193,7 +1193,7 @@ class DataFrameChecks:
         Args:
             fn: An optional lambda function to apply to the DataFrame before running Pandas hist(). Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before running Pandas hist(). Applied after fn.
-            msg: An optional name for the check, to be printed as preface to the result.
+            msg: Optionally customize the text displayed before the result of the check.
             **kwargs: Optional, additional arguments that are accepted by Pandas hist() method, such as `column`.
 
         Returns:
@@ -1241,7 +1241,7 @@ class DataFrameChecks:
         Args:
             fn: An optional lambda function to apply to the DataFrame before running Pandas info(). Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before running Pandas info(). Applied after fn.
-            msg: An optional name for the check, to be printed as preface to the result.
+            msg: Optionally customize the text displayed before the result of the check.
             **kwargs: Optional, additional arguments that are accepted by Pandas info() method.
 
         Returns:
@@ -1282,7 +1282,7 @@ class DataFrameChecks:
         Args:
             fn: An optional lambda function to apply to the DataFrame before running Pandas memory_usage(). Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before running Pandas memory_usage(). Applied after fn.
-            msg: An optional name for the check, to be printed as preface to the result.
+            msg: Optionally customize the text displayed before the result of the check.
             **kwargs: Optional, additional arguments that are accepted by Pandas info() method.
 
         Returns:
@@ -1319,7 +1319,7 @@ class DataFrameChecks:
         Args:
             fn: An optional lambda function to apply to the DataFrame before counting the number of columns. Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before counting the number of columns. Applied after fn.
-            msg: An optional name for the check, to be printed as preface to the result.
+            msg: Optionally customize the text displayed before the result of the check.
 
         Returns:
             The original DataFrame, unchanged.
@@ -1356,7 +1356,7 @@ class DataFrameChecks:
         Args:
             fn: An optional lambda function to apply to the DataFrame before counting the number of duplicates. Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before counting duplicate rows. Applied after fn.
-            msg: An optional name for the check, to be printed as preface to the result.
+            msg: Optionally customize the text displayed before the result of the check.
             **kwargs: Optional, additional arguments that are accepted by Pandas duplicated() method.
 
         Returns:
@@ -1405,7 +1405,7 @@ class DataFrameChecks:
             fn: An optional lambda function to apply to the DataFrame before counting the number of rows with a null. Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before counting nulls.
             by_column: If True, count null values with each column separately. If False, count rows with a null value in any column. Applied after fn.
-            msg: An optional name for the check, to be printed as preface to the result.
+            msg: Optionally customize the text displayed before the result of the check.
 
         Returns:
             The original DataFrame, unchanged.
@@ -1454,7 +1454,7 @@ class DataFrameChecks:
         Args:
             fn: An optional lambda function to apply to the DataFrame before counting the number of rows. Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string name of one column to limit which columns are considered when counting rows. Applied after fn.
-            msg: An optional name for the check, to be printed as preface to the result.
+            msg: Optionally customize the text displayed before the result of the check.
 
         Returns:
             The original DataFrame, unchanged.
@@ -1501,7 +1501,7 @@ class DataFrameChecks:
                 - count the unique values in each column separately (False), the standard Pandas DataFrame nunique()
                 - count the unique combinations of rows across those columns (True) or
             fn: An optional lambda function to apply to the DataFrame before running Pandas nunique(). Example: `lambda df: df.shape[0]>10`. Applied before subset.
-            msg: An optional name for the check, to be printed as preface to the result.
+            msg: Optionally customize the text displayed before the result of the check.
             **kwargs: Optional, additional arguments that are accepted by Pandas nunique() method(s)
 
         Returns:
@@ -1629,7 +1629,7 @@ class DataFrameChecks:
             object: Object to print. Can be anything printable: str, int, list, another DataFrame, etc. If None, print the DataFrame's head (with `max_rows` rows).
             fn: An optional lambda function to apply to the DataFrame before printing `object`. Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string name of one column to limit which columns are printed. Applied after fn.
-            msg: An optional name for the check, to be printed as preface to the result.
+            msg: Optionally customize the text displayed before the result of the check.
             max_rows: Maximum number of rows to print if object=None.
 
         Returns:
@@ -1789,7 +1789,7 @@ class DataFrameChecks:
         Args:
             fn: An optional lambda function to apply to the DataFrame before running Pandas `shape`. Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string name of one column to limit which columns are considered when printing the shape. Applied after fn.
-            msg: An optional name for the check, to be printed as preface to the result.
+            msg: Optionally customize the text displayed before the result of the check.
 
         Returns:
             The original DataFrame, unchanged.
@@ -1829,7 +1829,7 @@ class DataFrameChecks:
             n: Number of rows to show.
             fn: An optional lambda function to apply to the DataFrame before running Pandas tail(). Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string name of one column to limit which columns are displayed. Applied after fn.
-            msg: An optional name for the check, to be printed as preface to the result.
+            msg: Optionally customize the text displayed before the result of the check.
 
         Returns:
             The original DataFrame, unchanged.
@@ -1865,7 +1865,7 @@ class DataFrameChecks:
         Args:
             column: Column to check for unique values.
             fn: An optional lambda function to apply to the DataFrame before calling Pandas unique(). Example: `lambda df: df.shape[0]>10`. Applied before subset.
-            msg: An optional name for the check, to be printed as preface to the result.
+            msg: Optionally customize the text displayed before the result of the check.
 
         Returns:
             The original DataFrame, unchanged.
@@ -1910,7 +1910,7 @@ class DataFrameChecks:
             column: Column to check for value counts.
             max_rows: Maximum number of rows to show in the value counts.
             fn: An optional lambda function to apply to the DataFrame before running Pandas value_counts(). Example: `lambda df: df.shape[0]>10`. Applied before subset.
-            msg: An optional name for the check, to be printed as preface to the result.
+            msg: Optionally customize the text displayed before the result of the check.
             **kwargs: Optional, additional arguments that are accepted by Pandas value_counts() method.
 
         Returns:

--- a/pandas_checks/DataFrameChecks.py
+++ b/pandas_checks/DataFrameChecks.py
@@ -972,7 +972,7 @@ class DataFrameChecks:
     ) -> pd.DataFrame:
         """Displays descriptive statistics about a DataFrame without modifying the DataFrame itself.
 
-        See Pandas docs for [describe()](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.describe.html) for additional usage information, including more configuration options you can pass to this Pandas Checks method.
+        See Pandas docs for [describe()](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.describe.html) for additional usage information, including more options you can pass to this Pandas Checks method.
 
         Example:
             ```python
@@ -1177,7 +1177,7 @@ class DataFrameChecks:
 
         You can pass a single `column` (via kwargs) or a `subset` argument, which can display a grid of multiple histograms.
 
-        See Pandas docs for [hist()](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.hist.html) for additional usage information, including more configuration options you can pass to this Pandas Checks method via kwargs.
+        See Pandas docs for [hist()](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.hist.html) for additional usage information, including more options you can pass to this Pandas Checks method.
 
         Example:
             ```python
@@ -1228,7 +1228,7 @@ class DataFrameChecks:
     ) -> pd.DataFrame:
         """Displays summary information about a DataFrame, without modifying the DataFrame itself.
 
-        See Pandas docs for [info()](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.info.html) for additional usage information, including more configuration options you can pass to this Pandas Checks method.
+        See Pandas docs for [info()](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.info.html) for additional usage information, including more options you can pass to this Pandas Checks method.
 
         Example:
             ```python
@@ -1269,7 +1269,7 @@ class DataFrameChecks:
     ) -> pd.DataFrame:
         """Displays the memory footprint of a DataFrame, without modifying the DataFrame itself.
 
-        See Pandas docs for [memory_usage()](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.memory_usage.html) for additional usage information, including more configuration options you can pass to this Pandas Checks method.
+        See Pandas docs for [memory_usage()](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.memory_usage.html) for additional usage information, including more options you can pass to this Pandas Checks method.
 
         Example:
             ```python
@@ -1342,7 +1342,7 @@ class DataFrameChecks:
     ) -> pd.DataFrame:
         """Displays the number of duplicated rows in a DataFrame, without modifying the DataFrame itself.
 
-        See Pandas docs for [duplicated()](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.duplicated.html) for additional usage information, including more configuration options you can pass to this Pandas Checks method.
+        See Pandas docs for [duplicated()](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.duplicated.html) for additional usage information, including more options you can pass to this Pandas Checks method.
 
         Example:
             ```python
@@ -1565,7 +1565,7 @@ class DataFrameChecks:
     ) -> pd.DataFrame:
         """Displays a plot of the DataFrame, without modifying the DataFrame itself.
 
-        See Pandas docs for [plot()](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.plot.html) for additional usage information, including more configuration options you can pass to this Pandas Checks method.
+        See Pandas docs for [plot()](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.plot.html) for additional usage information, including more options you can pass to this Pandas Checks method.
 
         Example:
             ```python
@@ -1814,7 +1814,7 @@ class DataFrameChecks:
     ) -> pd.DataFrame:
         """Displays the last n rows of the DataFrame, without modifying the DataFrame itself.
 
-        See Pandas docs for [tail()](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.tail.html) for additional usage information, including more configuration options you can pass to this Pandas Checks method.
+        See Pandas docs for [tail()](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.tail.html) for additional usage information, including more options you can pass to this Pandas Checks method.
 
         Example:
             ```python
@@ -1850,7 +1850,7 @@ class DataFrameChecks:
     ) -> pd.DataFrame:
         """Displays the unique values in a column, without modifying the DataFrame itself.
 
-        See Pandas docs for [unique()](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.unique.html) for additional usage information, including more configuration options you can pass to this Pandas Checks method.
+        See Pandas docs for [unique()](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.unique.html) for additional usage information, including more options you can pass to this Pandas Checks method.
 
         Example:
             ```python
@@ -1895,7 +1895,7 @@ class DataFrameChecks:
     ) -> pd.DataFrame:
         """Displays the value counts for a column, without modifying the DataFrame itself.
 
-        See Pandas docs for [value_counts()](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.value_counts.html) for additional usage information, including more configuration options you can pass to this Pandas Checks method.
+        See Pandas docs for [value_counts()](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.value_counts.html) for additional usage information, including more options you can pass to this Pandas Checks method.
 
         Example:
             ```python
@@ -1951,7 +1951,7 @@ class DataFrameChecks:
             - .tsv # Tab-separated data file
             - .xlsx
 
-        This functions uses the corresponding Pandas export function, such as `to_csv()` and `to_feather()`. See [Pandas docs for those corresponding export functions](https://pandas.pydata.org/docs/reference/io.html) for additional usage information, including more configuration options you can pass to this Pandas Checks method.
+        This functions uses the corresponding Pandas export function, such as `to_csv()` and `to_feather()`. See [Pandas docs for those corresponding export functions](https://pandas.pydata.org/docs/reference/io.html) for additional usage information, including more options you can pass to this Pandas Checks method.
 
         Example:
             ```python

--- a/pandas_checks/DataFrameChecks.py
+++ b/pandas_checks/DataFrameChecks.py
@@ -949,7 +949,7 @@ class DataFrameChecks:
         Args:
             fn: An optional lambda function to apply to the DataFrame before printing columns. Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before printing their names. Applied after fn.
-            msg: An optional name for the check to preface the result with.
+            msg: Optionally customize the text displayed before the result of the check.
 
         Returns:
             The original DataFrame, unchanged.
@@ -985,7 +985,7 @@ class DataFrameChecks:
         Args:
             fn: An optional lambda function to apply to the DataFrame before running Pandas describe(). Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before running Pandas describe(). Applied after fn.
-            msg: An optional name for the check to preface the result with.
+            msg: Optionally customize the text displayed before the result of the check.
             **kwargs: Optional, additional arguments that are accepted by Pandas describe() method.
 
         Returns:
@@ -1041,7 +1041,7 @@ class DataFrameChecks:
         Args:
             fn: An optional lambda function to apply to the DataFrame before running Pandas dtypes. Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before running Pandas .dtypes. Applied after fn.
-            msg: An optional name for the check to preface the result with.
+            msg: Optionally customize the text displayed before the result of the check.
 
         Returns:
             The original DataFrame, unchanged.
@@ -1098,7 +1098,7 @@ class DataFrameChecks:
         Args:
             fn: A lambda function to apply to the DataFrame. Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before running Pandas describe(). Applied after fn.
-            msg: An optional name for the check to preface the result with.
+            msg: Optionally customize the text displayed before the result of the check.
 
         Returns:
             The original DataFrame, unchanged.
@@ -1121,7 +1121,7 @@ class DataFrameChecks:
             ```
 
         Args:
-            msg: An optional name for the check. Will be used as a preface the printed result.
+            msg: Optionally customize the text displayed before the result of the check.
 
         Returns:
             The original DataFrame, unchanged.
@@ -1152,7 +1152,7 @@ class DataFrameChecks:
             n: The number of rows to display.
             fn: An optional lambda function to apply to the DataFrame before running Pandas head(). Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before running Pandas head(). Applied after fn.
-            msg: An optional name for the check, to be printed as preface to the result.
+            msg: Optionally customize the text displayed before the result of the check.
 
         Returns:
             The original DataFrame, unchanged.
@@ -1193,7 +1193,7 @@ class DataFrameChecks:
         Args:
             fn: An optional lambda function to apply to the DataFrame before running Pandas hist(). Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before running Pandas hist(). Applied after fn.
-            msg: An optional name for the check, to be printed as preface to the result.
+            msg: Optionally customize the text displayed before the result of the check.
             **kwargs: Optional, additional arguments that are accepted by Pandas hist() method, such as `column`.
 
         Returns:
@@ -1241,7 +1241,7 @@ class DataFrameChecks:
         Args:
             fn: An optional lambda function to apply to the DataFrame before running Pandas info(). Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before running Pandas info(). Applied after fn.
-            msg: An optional name for the check, to be printed as preface to the result.
+            msg: Optionally customize the text displayed before the result of the check.
             **kwargs: Optional, additional arguments that are accepted by Pandas info() method.
 
         Returns:
@@ -1282,7 +1282,7 @@ class DataFrameChecks:
         Args:
             fn: An optional lambda function to apply to the DataFrame before running Pandas memory_usage(). Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before running Pandas memory_usage(). Applied after fn.
-            msg: An optional name for the check, to be printed as preface to the result.
+            msg: Optionally customize the text displayed before the result of the check.
             **kwargs: Optional, additional arguments that are accepted by Pandas info() method.
 
         Returns:
@@ -1319,7 +1319,7 @@ class DataFrameChecks:
         Args:
             fn: An optional lambda function to apply to the DataFrame before counting the number of columns. Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before counting the number of columns. Applied after fn.
-            msg: An optional name for the check, to be printed as preface to the result.
+            msg: Optionally customize the text displayed before the result of the check.
 
         Returns:
             The original DataFrame, unchanged.
@@ -1356,7 +1356,7 @@ class DataFrameChecks:
         Args:
             fn: An optional lambda function to apply to the DataFrame before counting the number of duplicates. Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before counting duplicate rows. Applied after fn.
-            msg: An optional name for the check, to be printed as preface to the result.
+            msg: Optionally customize the text displayed before the result of the check.
             **kwargs: Optional, additional arguments that are accepted by Pandas duplicated() method.
 
         Returns:
@@ -1405,7 +1405,7 @@ class DataFrameChecks:
             fn: An optional lambda function to apply to the DataFrame before counting the number of rows with a null. Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before counting nulls.
             by_column: If True, count null values with each column separately. If False, count rows with a null value in any column. Applied after fn.
-            msg: An optional name for the check, to be printed as preface to the result.
+            msg: Optionally customize the text displayed before the result of the check.
 
         Returns:
             The original DataFrame, unchanged.
@@ -1454,7 +1454,7 @@ class DataFrameChecks:
         Args:
             fn: An optional lambda function to apply to the DataFrame before counting the number of rows. Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string name of one column to limit which columns are considered when counting rows. Applied after fn.
-            msg: An optional name for the check, to be printed as preface to the result.
+            msg: Optionally customize the text displayed before the result of the check.
 
         Returns:
             The original DataFrame, unchanged.
@@ -1501,7 +1501,7 @@ class DataFrameChecks:
                 - count the unique values in each column separately (False), the standard Pandas DataFrame nunique()
                 - count the unique combinations of rows across those columns (True) or
             fn: An optional lambda function to apply to the DataFrame before running Pandas nunique(). Example: `lambda df: df.shape[0]>10`. Applied before subset.
-            msg: An optional name for the check, to be printed as preface to the result.
+            msg: Optionally customize the text displayed before the result of the check.
             **kwargs: Optional, additional arguments that are accepted by Pandas nunique() method(s)
 
         Returns:
@@ -1623,7 +1623,7 @@ class DataFrameChecks:
             object: Object to print. Can be anything printable: str, int, list, another DataFrame, etc. If None, print the DataFrame's head (with `max_rows` rows).
             fn: An optional lambda function to apply to the DataFrame before printing `object`. Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string name of one column to limit which columns are printed. Applied after fn.
-            msg: An optional name for the check, to be printed as preface to the result.
+            msg: Optionally customize the text displayed before the result of the check.
             max_rows: Maximum number of rows to print if object=None.
 
         Returns:
@@ -1783,7 +1783,7 @@ class DataFrameChecks:
         Args:
             fn: An optional lambda function to apply to the DataFrame before running Pandas `shape`. Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string name of one column to limit which columns are considered when printing the shape. Applied after fn.
-            msg: An optional name for the check, to be printed as preface to the result.
+            msg: Optionally customize the text displayed before the result of the check.
 
         Returns:
             The original DataFrame, unchanged.
@@ -1823,7 +1823,7 @@ class DataFrameChecks:
             n: Number of rows to show.
             fn: An optional lambda function to apply to the DataFrame before running Pandas tail(). Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string name of one column to limit which columns are displayed. Applied after fn.
-            msg: An optional name for the check, to be printed as preface to the result.
+            msg: Optionally customize the text displayed before the result of the check.
 
         Returns:
             The original DataFrame, unchanged.
@@ -1859,7 +1859,7 @@ class DataFrameChecks:
         Args:
             column: Column to check for unique values.
             fn: An optional lambda function to apply to the DataFrame before calling Pandas unique(). Example: `lambda df: df.shape[0]>10`. Applied before subset.
-            msg: An optional name for the check, to be printed as preface to the result.
+            msg: Optionally customize the text displayed before the result of the check.
 
         Returns:
             The original DataFrame, unchanged.
@@ -1904,7 +1904,7 @@ class DataFrameChecks:
             column: Column to check for value counts.
             max_rows: Maximum number of rows to show in the value counts.
             fn: An optional lambda function to apply to the DataFrame before running Pandas value_counts(). Example: `lambda df: df.shape[0]>10`. Applied before subset.
-            msg: An optional name for the check, to be printed as preface to the result.
+            msg: Optionally customize the text displayed before the result of the check.
             **kwargs: Optional, additional arguments that are accepted by Pandas value_counts() method.
 
         Returns:

--- a/pandas_checks/DataFrameChecks.py
+++ b/pandas_checks/DataFrameChecks.py
@@ -1335,8 +1335,8 @@ class DataFrameChecks:
 
     def ndups(
         self,
-        fn: Callable = lambda df: df,
         subset: Union[str, List, None] = None,
+        fn: Callable = lambda df: df,
         msg: Union[str, None] = None,
         **kwargs: Any,
     ) -> pd.DataFrame:
@@ -1354,8 +1354,8 @@ class DataFrameChecks:
             ```
 
         Args:
-            fn: An optional lambda function to apply to the DataFrame before counting the number of duplicates. Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before counting duplicate rows. Applied after fn.
+            fn: An optional lambda function to apply to the DataFrame before counting the number of duplicates. Example: `lambda df: df.shape[0]>10`. Applied before subset.
             msg: Optionally customize the text displayed before the result of the check.
             **kwargs: Optional, additional arguments that are accepted by Pandas duplicated() method.
 

--- a/pandas_checks/DataFrameChecks.py
+++ b/pandas_checks/DataFrameChecks.py
@@ -934,7 +934,7 @@ class DataFrameChecks:
         self,
         fn: Callable = lambda df: df,
         subset: Union[str, List, None] = None,
-        check_name: Union[str, None] = "🏛️ Columns",
+        msg: Union[str, None] = "🏛️ Columns",
     ) -> pd.DataFrame:
         """Prints the column names of a DataFrame, without modifying the DataFrame itself.
 
@@ -949,7 +949,7 @@ class DataFrameChecks:
         Args:
             fn: An optional lambda function to apply to the DataFrame before printing columns. Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before printing their names. Applied after fn.
-            check_name: An optional name for the check to preface the result with.
+            msg: An optional name for the check to preface the result with.
 
         Returns:
             The original DataFrame, unchanged.
@@ -959,7 +959,7 @@ class DataFrameChecks:
             check_fn=lambda df: df.columns.tolist(),
             modify_fn=fn,
             subset=subset,
-            check_name=check_name,
+            msg=msg,
         )
         return self._obj
 
@@ -967,7 +967,7 @@ class DataFrameChecks:
         self,
         fn: Callable = lambda df: df,
         subset: Union[str, List, None] = None,
-        check_name: Union[str, None] = "📏 Distributions",
+        msg: Union[str, None] = "📏 Distributions",
         **kwargs: Any,
     ) -> pd.DataFrame:
         """Displays descriptive statistics about a DataFrame without modifying the DataFrame itself.
@@ -985,7 +985,7 @@ class DataFrameChecks:
         Args:
             fn: An optional lambda function to apply to the DataFrame before running Pandas describe(). Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before running Pandas describe(). Applied after fn.
-            check_name: An optional name for the check to preface the result with.
+            msg: An optional name for the check to preface the result with.
             **kwargs: Optional, additional arguments that are accepted by Pandas describe() method.
 
         Returns:
@@ -996,7 +996,7 @@ class DataFrameChecks:
             check_fn=lambda df: df.describe(**kwargs),
             modify_fn=fn,
             subset=subset,
-            check_name=check_name,
+            msg=msg,
         )
         return self._obj
 
@@ -1026,7 +1026,7 @@ class DataFrameChecks:
         self,
         fn: Callable = lambda df: df,
         subset: Union[str, List, None] = None,
-        check_name: Union[str, None] = "🗂️ Data types",
+        msg: Union[str, None] = "🗂️ Data types",
     ) -> pd.DataFrame:
         """Displays the data types of a DataFrame's columns without modifying the DataFrame itself.
 
@@ -1041,7 +1041,7 @@ class DataFrameChecks:
         Args:
             fn: An optional lambda function to apply to the DataFrame before running Pandas dtypes. Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before running Pandas .dtypes. Applied after fn.
-            check_name: An optional name for the check to preface the result with.
+            msg: An optional name for the check to preface the result with.
 
         Returns:
             The original DataFrame, unchanged.
@@ -1051,7 +1051,7 @@ class DataFrameChecks:
             check_fn=lambda df: df.dtypes,
             modify_fn=fn,
             subset=subset,
-            check_name=check_name,
+            msg=msg,
         )
         return self._obj
 
@@ -1082,7 +1082,7 @@ class DataFrameChecks:
         self,
         fn: Callable = lambda df: df,
         subset: Union[str, List, None] = None,
-        check_name: Union[str, None] = None,
+        msg: Union[str, None] = None,
     ) -> pd.DataFrame:
         """Applies an arbitrary function on a DataFrame and shows the result, without modifying the DataFrame itself.
 
@@ -1090,7 +1090,7 @@ class DataFrameChecks:
             ```python
                 (
                     iris
-                    .check.function(fn=lambda df: df.shape[0]>10, check_name='Has at least 10 rows?')
+                    .check.function(fn=lambda df: df.shape[0]>10, msg='Has at least 10 rows?')
                 )
                 # Will return either 'True' or 'False'
             ```
@@ -1098,17 +1098,15 @@ class DataFrameChecks:
         Args:
             fn: A lambda function to apply to the DataFrame. Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before running Pandas describe(). Applied after fn.
-            check_name: An optional name for the check to preface the result with.
+            msg: An optional name for the check to preface the result with.
 
         Returns:
             The original DataFrame, unchanged.
         """
-        _check_data(self._obj, modify_fn=fn, subset=subset, check_name=check_name)
+        _check_data(self._obj, modify_fn=fn, subset=subset, msg=msg)
         return self._obj
 
-    def get_mode(
-        self, check_name: Union[str, None] = "🐼🩺 Pandas Checks mode"
-    ) -> pd.DataFrame:
+    def get_mode(self, msg: Union[str, None] = "🐼🩺 Pandas Checks mode") -> pd.DataFrame:
         """Displays the current values of Pandas Checks global options enable_checks and enable_asserts. Does not modify the DataFrame itself.
 
         Example:
@@ -1123,12 +1121,12 @@ class DataFrameChecks:
             ```
 
         Args:
-            check_name: An optional name for the check. Will be used as a preface the printed result.
+            msg: An optional name for the check. Will be used as a preface the printed result.
 
         Returns:
             The original DataFrame, unchanged.
         """
-        _display_line(lead_in=check_name, line=str(get_mode()))
+        _display_line(lead_in=msg, line=str(get_mode()))
         return self._obj
 
     def head(
@@ -1136,7 +1134,7 @@ class DataFrameChecks:
         n: int = 5,
         fn: Callable = lambda df: df,
         subset: Union[str, List, None] = None,
-        check_name: Union[str, None] = None,
+        msg: Union[str, None] = None,
     ) -> pd.DataFrame:
         """Displays the first n rows of a DataFrame, without modifying the DataFrame itself.
 
@@ -1154,7 +1152,7 @@ class DataFrameChecks:
             n: The number of rows to display.
             fn: An optional lambda function to apply to the DataFrame before running Pandas head(). Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before running Pandas head(). Applied after fn.
-            check_name: An optional name for the check, to be printed as preface to the result.
+            msg: An optional name for the check, to be printed as preface to the result.
 
         Returns:
             The original DataFrame, unchanged.
@@ -1164,7 +1162,7 @@ class DataFrameChecks:
             check_fn=lambda df: df.head(n),
             modify_fn=fn,
             subset=subset,
-            check_name=check_name if check_name else f"⬆️ First {n} rows",
+            msg=msg if msg else f"⬆️ First {n} rows",
         )
         return self._obj
 
@@ -1172,7 +1170,7 @@ class DataFrameChecks:
         self,
         fn: Callable = lambda df: df,
         subset: Union[str, List, None] = [],
-        check_name: Union[str, None] = None,
+        msg: Union[str, None] = None,
         **kwargs: Any,
     ) -> pd.DataFrame:
         """Displays a histogram for the DataFrame, without modifying the DataFrame itself.
@@ -1195,7 +1193,7 @@ class DataFrameChecks:
         Args:
             fn: An optional lambda function to apply to the DataFrame before running Pandas hist(). Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before running Pandas hist(). Applied after fn.
-            check_name: An optional name for the check, to be printed as preface to the result.
+            msg: An optional name for the check, to be printed as preface to the result.
             **kwargs: Optional, additional arguments that are accepted by Pandas hist() method, such as `column`.
 
         Returns:
@@ -1204,19 +1202,19 @@ class DataFrameChecks:
         Note:
             Only renders in interactive mode (IPython/Jupyter), not in terminal.
         """
-        if not check_name:
+        if not msg:
             if isinstance(subset, list) and len(subset) == 1:
-                check_name = f"📏 Distribution of '{subset[0]}'"
+                msg = f"📏 Distribution of '{subset[0]}'"
             elif isinstance(subset, str):
-                check_name = f"📏 Distribution of '{subset}'"
+                msg = f"📏 Distribution of '{subset}'"
             elif "column" in kwargs:
                 col_name = kwargs["column"]
-                check_name = f"📏 Distribution of '{col_name}'"
+                msg = f"📏 Distribution of '{col_name}'"
             else:
-                check_name = "📏 Distributions"
+                msg = "📏 Distributions"
         # Only display if in IPython/Jupyter, or we'd just print the title
         if get_mode()["enable_checks"] and not pd.core.config_init.is_terminal():
-            _display_plot_title(check_name)
+            _display_plot_title(msg)
             _ = _apply_modifications(self._obj, fn, subset).hist(**kwargs)
             _display_plot()
         return self._obj
@@ -1225,7 +1223,7 @@ class DataFrameChecks:
         self,
         fn: Callable = lambda df: df,
         subset: Union[str, List, None] = None,
-        check_name: Union[str, None] = "ℹ️ Info",
+        msg: Union[str, None] = "ℹ️ Info",
         **kwargs: Any,
     ) -> pd.DataFrame:
         """Displays summary information about a DataFrame, without modifying the DataFrame itself.
@@ -1243,15 +1241,15 @@ class DataFrameChecks:
         Args:
             fn: An optional lambda function to apply to the DataFrame before running Pandas info(). Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before running Pandas info(). Applied after fn.
-            check_name: An optional name for the check, to be printed as preface to the result.
+            msg: An optional name for the check, to be printed as preface to the result.
             **kwargs: Optional, additional arguments that are accepted by Pandas info() method.
 
         Returns:
             The original DataFrame, unchanged.
         """
         if get_mode()["enable_checks"]:
-            if check_name:
-                _display_table_title(check_name)
+            if msg:
+                _display_table_title(msg)
             df_modified = _apply_modifications(self._obj, fn, subset)
             # Get the Pandas info() result as a string
             buffer = io.StringIO()
@@ -1266,7 +1264,7 @@ class DataFrameChecks:
         self,
         fn: Callable = lambda df: df,
         subset: Union[str, List, None] = None,
-        check_name: Union[str, None] = "💾 Memory usage",
+        msg: Union[str, None] = "💾 Memory usage",
         **kwargs: Any,
     ) -> pd.DataFrame:
         """Displays the memory footprint of a DataFrame, without modifying the DataFrame itself.
@@ -1284,7 +1282,7 @@ class DataFrameChecks:
         Args:
             fn: An optional lambda function to apply to the DataFrame before running Pandas memory_usage(). Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before running Pandas memory_usage(). Applied after fn.
-            check_name: An optional name for the check, to be printed as preface to the result.
+            msg: An optional name for the check, to be printed as preface to the result.
             **kwargs: Optional, additional arguments that are accepted by Pandas info() method.
 
         Returns:
@@ -1298,7 +1296,7 @@ class DataFrameChecks:
             check_fn=lambda df: df.memory_usage(**kwargs),
             modify_fn=fn,
             subset=subset,
-            check_name=check_name,
+            msg=msg,
         )
         return self._obj
 
@@ -1306,7 +1304,7 @@ class DataFrameChecks:
         self,
         fn: Callable = lambda df: df,
         subset: Union[str, List, None] = None,
-        check_name: Union[str, None] = "🏛️ Columns",
+        msg: Union[str, None] = "🏛️ Columns",
     ) -> pd.DataFrame:
         """Displays the number of columns in a DataFrame, without modifying the DataFrame itself.
 
@@ -1321,7 +1319,7 @@ class DataFrameChecks:
         Args:
             fn: An optional lambda function to apply to the DataFrame before counting the number of columns. Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before counting the number of columns. Applied after fn.
-            check_name: An optional name for the check, to be printed as preface to the result.
+            msg: An optional name for the check, to be printed as preface to the result.
 
         Returns:
             The original DataFrame, unchanged.
@@ -1331,7 +1329,7 @@ class DataFrameChecks:
             check_fn=lambda df: df.shape[1],
             modify_fn=fn,
             subset=subset,
-            check_name=check_name,
+            msg=msg,
         )
         return self._obj
 
@@ -1339,7 +1337,7 @@ class DataFrameChecks:
         self,
         fn: Callable = lambda df: df,
         subset: Union[str, List, None] = None,
-        check_name: Union[str, None] = None,
+        msg: Union[str, None] = None,
         **kwargs: Any,
     ) -> pd.DataFrame:
         """Displays the number of duplicated rows in a DataFrame, without modifying the DataFrame itself.
@@ -1358,7 +1356,7 @@ class DataFrameChecks:
         Args:
             fn: An optional lambda function to apply to the DataFrame before counting the number of duplicates. Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before counting duplicate rows. Applied after fn.
-            check_name: An optional name for the check, to be printed as preface to the result.
+            msg: An optional name for the check, to be printed as preface to the result.
             **kwargs: Optional, additional arguments that are accepted by Pandas duplicated() method.
 
         Returns:
@@ -1369,8 +1367,8 @@ class DataFrameChecks:
             check_fn=lambda df: df.duplicated(**kwargs).sum(),
             modify_fn=fn,
             subset=subset,
-            check_name=check_name
-            if check_name
+            msg=msg
+            if msg
             else f"👯‍♂️ Rows with duplication in '{subset}'"
             if subset
             else "👯‍♂️ Duplicated rows",
@@ -1382,7 +1380,7 @@ class DataFrameChecks:
         fn: Callable = lambda df: df,
         subset: Union[str, List, None] = None,
         by_column: bool = True,
-        check_name: Union[str, None] = "👻 Rows with NaNs",
+        msg: Union[str, None] = "👻 Rows with NaNs",
     ) -> pd.DataFrame:
         """Displays the number of rows with null values in a DataFrame, without modifying the DataFrame itself.
 
@@ -1407,7 +1405,7 @@ class DataFrameChecks:
             fn: An optional lambda function to apply to the DataFrame before counting the number of rows with a null. Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before counting nulls.
             by_column: If True, count null values with each column separately. If False, count rows with a null value in any column. Applied after fn.
-            check_name: An optional name for the check, to be printed as preface to the result.
+            msg: An optional name for the check, to be printed as preface to the result.
 
         Returns:
             The original DataFrame, unchanged.
@@ -1427,15 +1425,13 @@ class DataFrameChecks:
         ):  # Report result as a pandas object
             _check_data(
                 na_counts,
-                check_name=f"👻 Rows with NaNs in {subset}"
-                if subset and not check_name
-                else check_name,
+                msg=f"👻 Rows with NaNs in {subset}" if subset and not msg else msg,
             )
         else:  # Report on one line
             _display_line(
                 (f"👻 Rows with NaNs in {subset}: {na_counts} out of {data.shape[0]}")
-                if subset and not check_name
-                else f"{check_name}: {na_counts}"
+                if subset and not msg
+                else f"{msg}: {na_counts}"
             )
         return self._obj
 
@@ -1443,7 +1439,7 @@ class DataFrameChecks:
         self,
         fn: Callable = lambda df: df,
         subset: Union[str, List, None] = None,
-        check_name: Union[str, None] = "☰ Rows",
+        msg: Union[str, None] = "☰ Rows",
     ) -> pd.DataFrame:
         """Displays the number of rows in a DataFrame, without modifying the DataFrame itself.
 
@@ -1458,7 +1454,7 @@ class DataFrameChecks:
         Args:
             fn: An optional lambda function to apply to the DataFrame before counting the number of rows. Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string name of one column to limit which columns are considered when counting rows. Applied after fn.
-            check_name: An optional name for the check, to be printed as preface to the result.
+            msg: An optional name for the check, to be printed as preface to the result.
 
         Returns:
             The original DataFrame, unchanged.
@@ -1468,7 +1464,7 @@ class DataFrameChecks:
             check_fn=lambda df: df.shape[0],
             modify_fn=fn,
             subset=subset,
-            check_name=check_name,
+            msg=msg,
         )
         return self._obj
 
@@ -1478,7 +1474,7 @@ class DataFrameChecks:
         subset: Union[str, List, None] = None,
         across_columns: bool = False,
         fn: Callable = lambda df: df,
-        check_name: Union[str, None] = None,
+        msg: Union[str, None] = None,
         **kwargs: Any,
     ) -> pd.DataFrame:
         """Displays the number of unique values in a Series or unique combinations of rows in a DataFrame, without modifying the DataFrame itself.
@@ -1505,7 +1501,7 @@ class DataFrameChecks:
                 - count the unique values in each column separately (False), the standard Pandas DataFrame nunique()
                 - count the unique combinations of rows across those columns (True) or
             fn: An optional lambda function to apply to the DataFrame before running Pandas nunique(). Example: `lambda df: df.shape[0]>10`. Applied before subset.
-            check_name: An optional name for the check, to be printed as preface to the result.
+            msg: An optional name for the check, to be printed as preface to the result.
             **kwargs: Optional, additional arguments that are accepted by Pandas nunique() method(s)
 
         Returns:
@@ -1524,14 +1520,14 @@ class DataFrameChecks:
 
             data_modified = _apply_modifications(self._obj, fn=fn, subset=subset)
 
-            if not check_name:
+            if not msg:
                 if subset:
                     if isinstance(subset, str):
-                        check_name = f"🌟 Unique values in '{subset}'"
+                        msg = f"🌟 Unique values in '{subset}'"
                     else:
-                        check_name = f"🌟 Unique values in {subset}"
+                        msg = f"🌟 Unique values in {subset}"
                 else:
-                    check_name = "🌟 Unique values"
+                    msg = "🌟 Unique values"
 
             if not across_columns:
                 # Run standard Pandas nunique()
@@ -1540,7 +1536,7 @@ class DataFrameChecks:
                     data_modified,
                     check_fn=lambda data: data.nunique(**kwargs),
                     modify_fn=fn,
-                    check_name=check_name,
+                    msg=msg,
                 )  # fmt: skip
             else:
                 # Count the number of unique rows considering values in multiple columns
@@ -1551,7 +1547,7 @@ class DataFrameChecks:
                 (
                     data_modified
                     .drop_duplicates()
-                    .check.nrows(check_name=check_name)
+                    .check.nrows(msg=msg)
                 )  # fmt: skip
         return self._obj
 
@@ -1559,7 +1555,7 @@ class DataFrameChecks:
         self,
         fn: Callable = lambda df: df,
         subset: Union[str, List, None] = None,
-        check_name: Union[str, None] = "",
+        msg: Union[str, None] = "",
         **kwargs: Any,
     ) -> pd.DataFrame:
         """Displays a plot of the DataFrame, without modifying the DataFrame itself.
@@ -1577,7 +1573,7 @@ class DataFrameChecks:
         Args:
             fn: An optional lambda function to apply to the DataFrame before running Pandas plot(). Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string name of one column to limit which columns are plotted. Applied after fn.
-            check_name: An optional title for the plot.
+            msg: An optional title for the plot.
             **kwargs: Optional, additional arguments that are accepted by Pandas plot() method.
 
         Returns:
@@ -1586,14 +1582,12 @@ class DataFrameChecks:
         Note:
             Plots are only displayed when code is run in IPython/Jupyter, not in terminal.
 
-            If you pass a 'title' kwarg, it becomes the plot title, overriding check_name
+            If you pass a 'title' kwarg, it becomes the plot title, overriding msg
         """
 
         # Only display plot if in IPython/Jupyter. Or we'd just print its title.
         if get_mode()["enable_checks"] and not pd.core.config_init.is_terminal():
-            _display_plot_title(
-                check_name if "title" not in kwargs else kwargs["title"]
-            )
+            _display_plot_title(msg if "title" not in kwargs else kwargs["title"])
             _ = _apply_modifications(self._obj, fn, subset).plot(**kwargs)
             _display_plot()
         return self._obj
@@ -1603,7 +1597,7 @@ class DataFrameChecks:
         object: Any = None,
         fn: Callable = lambda df: df,
         subset: Union[str, List, None] = None,
-        check_name: Union[str, None] = None,
+        msg: Union[str, None] = None,
         max_rows: int = 10,
     ) -> pd.DataFrame:
         """Displays text, another object, or (by default) the current DataFrame's head. Does not modify the DataFrame itself.
@@ -1621,7 +1615,7 @@ class DataFrameChecks:
                 (
                     iris
                     ...
-                    .check.print(fn=lambda df: df.query("sepal_width<0"), check_name="Rows with negative sepal_width")
+                    .check.print(fn=lambda df: df.query("sepal_width<0"), msg="Rows with negative sepal_width")
                 )
             ```
 
@@ -1629,7 +1623,7 @@ class DataFrameChecks:
             object: Object to print. Can be anything printable: str, int, list, another DataFrame, etc. If None, print the DataFrame's head (with `max_rows` rows).
             fn: An optional lambda function to apply to the DataFrame before printing `object`. Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string name of one column to limit which columns are printed. Applied after fn.
-            check_name: An optional name for the check, to be printed as preface to the result.
+            msg: An optional name for the check, to be printed as preface to the result.
             max_rows: Maximum number of rows to print if object=None.
 
         Returns:
@@ -1640,7 +1634,7 @@ class DataFrameChecks:
             check_fn=lambda data: data if object else data.head(max_rows),
             modify_fn=fn,
             subset=subset,
-            check_name=check_name,
+            msg=msg,
         )
         return self._obj
 
@@ -1773,7 +1767,7 @@ class DataFrameChecks:
         self,
         fn: Callable = lambda df: df,
         subset: Union[str, List, None] = None,
-        check_name: Union[str, None] = "📐 Shape",
+        msg: Union[str, None] = "📐 Shape",
     ) -> pd.DataFrame:
         """Displays the Dataframe's dimensions, without modifying the DataFrame itself.
 
@@ -1782,14 +1776,14 @@ class DataFrameChecks:
                 (
                     iris
                     .check.shape()
-                    .check.shape(fn=lambda df: df.query("sepal_length<5"), check_name="Shape of DataFrame subgroup with sepal_length<5")
+                    .check.shape(fn=lambda df: df.query("sepal_length<5"), msg="Shape of DataFrame subgroup with sepal_length<5")
                 )
             ```
 
         Args:
             fn: An optional lambda function to apply to the DataFrame before running Pandas `shape`. Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string name of one column to limit which columns are considered when printing the shape. Applied after fn.
-            check_name: An optional name for the check, to be printed as preface to the result.
+            msg: An optional name for the check, to be printed as preface to the result.
 
         Returns:
             The original DataFrame, unchanged.
@@ -1802,7 +1796,7 @@ class DataFrameChecks:
             check_fn=lambda df: df.shape,
             modify_fn=fn,
             subset=subset,
-            check_name=check_name,
+            msg=msg,
         )
         return self._obj
 
@@ -1811,7 +1805,7 @@ class DataFrameChecks:
         n: int = 5,
         fn: Callable = lambda df: df,
         subset: Union[str, List, None] = None,
-        check_name: Union[str, None] = None,
+        msg: Union[str, None] = None,
     ) -> pd.DataFrame:
         """Displays the last n rows of the DataFrame, without modifying the DataFrame itself.
 
@@ -1829,7 +1823,7 @@ class DataFrameChecks:
             n: Number of rows to show.
             fn: An optional lambda function to apply to the DataFrame before running Pandas tail(). Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string name of one column to limit which columns are displayed. Applied after fn.
-            check_name: An optional name for the check, to be printed as preface to the result.
+            msg: An optional name for the check, to be printed as preface to the result.
 
         Returns:
             The original DataFrame, unchanged.
@@ -1839,7 +1833,7 @@ class DataFrameChecks:
             check_fn=lambda df: df.tail(n),
             modify_fn=fn,
             subset=subset,
-            check_name=check_name if check_name else f"⬇️ Last {n} rows",
+            msg=msg if msg else f"⬇️ Last {n} rows",
         )
         return self._obj
 
@@ -1847,7 +1841,7 @@ class DataFrameChecks:
         self,
         column: str,
         fn: Callable = lambda df: df,
-        check_name: Union[str, None] = None,
+        msg: Union[str, None] = None,
     ) -> pd.DataFrame:
         """Displays the unique values in a column, without modifying the DataFrame itself.
 
@@ -1865,7 +1859,7 @@ class DataFrameChecks:
         Args:
             column: Column to check for unique values.
             fn: An optional lambda function to apply to the DataFrame before calling Pandas unique(). Example: `lambda df: df.shape[0]>10`. Applied before subset.
-            check_name: An optional name for the check, to be printed as preface to the result.
+            msg: An optional name for the check, to be printed as preface to the result.
 
         Returns:
             The original DataFrame, unchanged.
@@ -1881,7 +1875,7 @@ class DataFrameChecks:
                 # Use SeriesChecks method
                 .check.unique(
                     fn=lambda s: s,  # Identify function
-                    check_name=check_name,
+                    msg=msg,
                 )
             )  # fmt: skip
         return self._obj
@@ -1891,7 +1885,7 @@ class DataFrameChecks:
         column: str,
         fn: Callable = lambda df: df,
         max_rows: int = 10,
-        check_name: Union[str, None] = None,
+        msg: Union[str, None] = None,
         **kwargs: Any,
     ) -> pd.DataFrame:
         """Displays the value counts for a column, without modifying the DataFrame itself.
@@ -1910,7 +1904,7 @@ class DataFrameChecks:
             column: Column to check for value counts.
             max_rows: Maximum number of rows to show in the value counts.
             fn: An optional lambda function to apply to the DataFrame before running Pandas value_counts(). Example: `lambda df: df.shape[0]>10`. Applied before subset.
-            check_name: An optional name for the check, to be printed as preface to the result.
+            msg: An optional name for the check, to be printed as preface to the result.
             **kwargs: Optional, additional arguments that are accepted by Pandas value_counts() method.
 
         Returns:
@@ -1927,7 +1921,7 @@ class DataFrameChecks:
                 .check.value_counts(
                     max_rows=max_rows,
                     fn=lambda s: s,  # Identity function
-                    check_name=check_name,
+                    msg=msg,
                     **kwargs,
                 )
             )  # fmt: skip

--- a/pandas_checks/DataFrameChecks.py
+++ b/pandas_checks/DataFrameChecks.py
@@ -934,7 +934,7 @@ class DataFrameChecks:
         self,
         fn: Callable = lambda df: df,
         subset: Union[str, List, None] = None,
-        check_name: Union[str, None] = "🏛️ Columns",
+        msg: Union[str, None] = "🏛️ Columns",
     ) -> pd.DataFrame:
         """Prints the column names of a DataFrame, without modifying the DataFrame itself.
 
@@ -949,7 +949,7 @@ class DataFrameChecks:
         Args:
             fn: An optional lambda function to apply to the DataFrame before printing columns. Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before printing their names. Applied after fn.
-            check_name: An optional name for the check to preface the result with.
+            msg: An optional name for the check to preface the result with.
 
         Returns:
             The original DataFrame, unchanged.
@@ -959,7 +959,7 @@ class DataFrameChecks:
             check_fn=lambda df: df.columns.tolist(),
             modify_fn=fn,
             subset=subset,
-            check_name=check_name,
+            msg=msg,
         )
         return self._obj
 
@@ -967,7 +967,7 @@ class DataFrameChecks:
         self,
         fn: Callable = lambda df: df,
         subset: Union[str, List, None] = None,
-        check_name: Union[str, None] = "📏 Distributions",
+        msg: Union[str, None] = "📏 Distributions",
         **kwargs: Any,
     ) -> pd.DataFrame:
         """Displays descriptive statistics about a DataFrame without modifying the DataFrame itself.
@@ -985,7 +985,7 @@ class DataFrameChecks:
         Args:
             fn: An optional lambda function to apply to the DataFrame before running Pandas describe(). Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before running Pandas describe(). Applied after fn.
-            check_name: An optional name for the check to preface the result with.
+            msg: An optional name for the check to preface the result with.
             **kwargs: Optional, additional arguments that are accepted by Pandas describe() method.
 
         Returns:
@@ -996,7 +996,7 @@ class DataFrameChecks:
             check_fn=lambda df: df.describe(**kwargs),
             modify_fn=fn,
             subset=subset,
-            check_name=check_name,
+            msg=msg,
         )
         return self._obj
 
@@ -1026,7 +1026,7 @@ class DataFrameChecks:
         self,
         fn: Callable = lambda df: df,
         subset: Union[str, List, None] = None,
-        check_name: Union[str, None] = "🗂️ Data types",
+        msg: Union[str, None] = "🗂️ Data types",
     ) -> pd.DataFrame:
         """Displays the data types of a DataFrame's columns without modifying the DataFrame itself.
 
@@ -1041,7 +1041,7 @@ class DataFrameChecks:
         Args:
             fn: An optional lambda function to apply to the DataFrame before running Pandas dtypes. Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before running Pandas .dtypes. Applied after fn.
-            check_name: An optional name for the check to preface the result with.
+            msg: An optional name for the check to preface the result with.
 
         Returns:
             The original DataFrame, unchanged.
@@ -1051,7 +1051,7 @@ class DataFrameChecks:
             check_fn=lambda df: df.dtypes,
             modify_fn=fn,
             subset=subset,
-            check_name=check_name,
+            msg=msg,
         )
         return self._obj
 
@@ -1082,7 +1082,7 @@ class DataFrameChecks:
         self,
         fn: Callable = lambda df: df,
         subset: Union[str, List, None] = None,
-        check_name: Union[str, None] = None,
+        msg: Union[str, None] = None,
     ) -> pd.DataFrame:
         """Applies an arbitrary function on a DataFrame and shows the result, without modifying the DataFrame itself.
 
@@ -1090,7 +1090,7 @@ class DataFrameChecks:
             ```python
                 (
                     iris
-                    .check.function(fn=lambda df: df.shape[0]>10, check_name='Has at least 10 rows?')
+                    .check.function(fn=lambda df: df.shape[0]>10, msg='Has at least 10 rows?')
                 )
                 # Will return either 'True' or 'False'
             ```
@@ -1098,17 +1098,15 @@ class DataFrameChecks:
         Args:
             fn: A lambda function to apply to the DataFrame. Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before running Pandas describe(). Applied after fn.
-            check_name: An optional name for the check to preface the result with.
+            msg: An optional name for the check to preface the result with.
 
         Returns:
             The original DataFrame, unchanged.
         """
-        _check_data(self._obj, modify_fn=fn, subset=subset, check_name=check_name)
+        _check_data(self._obj, modify_fn=fn, subset=subset, msg=msg)
         return self._obj
 
-    def get_mode(
-        self, check_name: Union[str, None] = "🐼🩺 Pandas Checks mode"
-    ) -> pd.DataFrame:
+    def get_mode(self, msg: Union[str, None] = "🐼🩺 Pandas Checks mode") -> pd.DataFrame:
         """Displays the current values of Pandas Checks global options enable_checks and enable_asserts. Does not modify the DataFrame itself.
 
         Example:
@@ -1123,12 +1121,12 @@ class DataFrameChecks:
             ```
 
         Args:
-            check_name: An optional name for the check. Will be used as a preface the printed result.
+            msg: An optional name for the check. Will be used as a preface the printed result.
 
         Returns:
             The original DataFrame, unchanged.
         """
-        _display_line(lead_in=check_name, line=str(get_mode()))
+        _display_line(lead_in=msg, line=str(get_mode()))
         return self._obj
 
     def head(
@@ -1136,7 +1134,7 @@ class DataFrameChecks:
         n: int = 5,
         fn: Callable = lambda df: df,
         subset: Union[str, List, None] = None,
-        check_name: Union[str, None] = None,
+        msg: Union[str, None] = None,
     ) -> pd.DataFrame:
         """Displays the first n rows of a DataFrame, without modifying the DataFrame itself.
 
@@ -1154,7 +1152,7 @@ class DataFrameChecks:
             n: The number of rows to display.
             fn: An optional lambda function to apply to the DataFrame before running Pandas head(). Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before running Pandas head(). Applied after fn.
-            check_name: An optional name for the check, to be printed as preface to the result.
+            msg: An optional name for the check, to be printed as preface to the result.
 
         Returns:
             The original DataFrame, unchanged.
@@ -1164,7 +1162,7 @@ class DataFrameChecks:
             check_fn=lambda df: df.head(n),
             modify_fn=fn,
             subset=subset,
-            check_name=check_name if check_name else f"⬆️ First {n} rows",
+            msg=msg if msg else f"⬆️ First {n} rows",
         )
         return self._obj
 
@@ -1172,7 +1170,7 @@ class DataFrameChecks:
         self,
         fn: Callable = lambda df: df,
         subset: Union[str, List, None] = [],
-        check_name: Union[str, None] = None,
+        msg: Union[str, None] = None,
         **kwargs: Any,
     ) -> pd.DataFrame:
         """Displays a histogram for the DataFrame, without modifying the DataFrame itself.
@@ -1195,7 +1193,7 @@ class DataFrameChecks:
         Args:
             fn: An optional lambda function to apply to the DataFrame before running Pandas hist(). Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before running Pandas hist(). Applied after fn.
-            check_name: An optional name for the check, to be printed as preface to the result.
+            msg: An optional name for the check, to be printed as preface to the result.
             **kwargs: Optional, additional arguments that are accepted by Pandas hist() method, such as `column`.
 
         Returns:
@@ -1204,19 +1202,19 @@ class DataFrameChecks:
         Note:
             Only renders in interactive mode (IPython/Jupyter), not in terminal.
         """
-        if not check_name:
+        if not msg:
             if isinstance(subset, list) and len(subset) == 1:
-                check_name = f"📏 Distribution of '{subset[0]}'"
+                msg = f"📏 Distribution of '{subset[0]}'"
             elif isinstance(subset, str):
-                check_name = f"📏 Distribution of '{subset}'"
+                msg = f"📏 Distribution of '{subset}'"
             elif "column" in kwargs:
                 col_name = kwargs["column"]
-                check_name = f"📏 Distribution of '{col_name}'"
+                msg = f"📏 Distribution of '{col_name}'"
             else:
-                check_name = "📏 Distributions"
+                msg = "📏 Distributions"
         # Only display if in IPython/Jupyter, or we'd just print the title
         if get_mode()["enable_checks"] and not pd.core.config_init.is_terminal():
-            _display_plot_title(check_name)
+            _display_plot_title(msg)
             _ = _apply_modifications(self._obj, fn, subset).hist(**kwargs)
             _display_plot()
         return self._obj
@@ -1225,7 +1223,7 @@ class DataFrameChecks:
         self,
         fn: Callable = lambda df: df,
         subset: Union[str, List, None] = None,
-        check_name: Union[str, None] = "ℹ️ Info",
+        msg: Union[str, None] = "ℹ️ Info",
         **kwargs: Any,
     ) -> pd.DataFrame:
         """Displays summary information about a DataFrame, without modifying the DataFrame itself.
@@ -1243,15 +1241,15 @@ class DataFrameChecks:
         Args:
             fn: An optional lambda function to apply to the DataFrame before running Pandas info(). Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before running Pandas info(). Applied after fn.
-            check_name: An optional name for the check, to be printed as preface to the result.
+            msg: An optional name for the check, to be printed as preface to the result.
             **kwargs: Optional, additional arguments that are accepted by Pandas info() method.
 
         Returns:
             The original DataFrame, unchanged.
         """
         if get_mode()["enable_checks"]:
-            if check_name:
-                _display_table_title(check_name)
+            if msg:
+                _display_table_title(msg)
             df_modified = _apply_modifications(self._obj, fn, subset)
             # Get the Pandas info() result as a string
             buffer = io.StringIO()
@@ -1266,7 +1264,7 @@ class DataFrameChecks:
         self,
         fn: Callable = lambda df: df,
         subset: Union[str, List, None] = None,
-        check_name: Union[str, None] = "💾 Memory usage",
+        msg: Union[str, None] = "💾 Memory usage",
         **kwargs: Any,
     ) -> pd.DataFrame:
         """Displays the memory footprint of a DataFrame, without modifying the DataFrame itself.
@@ -1284,7 +1282,7 @@ class DataFrameChecks:
         Args:
             fn: An optional lambda function to apply to the DataFrame before running Pandas memory_usage(). Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before running Pandas memory_usage(). Applied after fn.
-            check_name: An optional name for the check, to be printed as preface to the result.
+            msg: An optional name for the check, to be printed as preface to the result.
             **kwargs: Optional, additional arguments that are accepted by Pandas info() method.
 
         Returns:
@@ -1298,7 +1296,7 @@ class DataFrameChecks:
             check_fn=lambda df: df.memory_usage(**kwargs),
             modify_fn=fn,
             subset=subset,
-            check_name=check_name,
+            msg=msg,
         )
         return self._obj
 
@@ -1306,7 +1304,7 @@ class DataFrameChecks:
         self,
         fn: Callable = lambda df: df,
         subset: Union[str, List, None] = None,
-        check_name: Union[str, None] = "🏛️ Columns",
+        msg: Union[str, None] = "🏛️ Columns",
     ) -> pd.DataFrame:
         """Displays the number of columns in a DataFrame, without modifying the DataFrame itself.
 
@@ -1321,7 +1319,7 @@ class DataFrameChecks:
         Args:
             fn: An optional lambda function to apply to the DataFrame before counting the number of columns. Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before counting the number of columns. Applied after fn.
-            check_name: An optional name for the check, to be printed as preface to the result.
+            msg: An optional name for the check, to be printed as preface to the result.
 
         Returns:
             The original DataFrame, unchanged.
@@ -1331,7 +1329,7 @@ class DataFrameChecks:
             check_fn=lambda df: df.shape[1],
             modify_fn=fn,
             subset=subset,
-            check_name=check_name,
+            msg=msg,
         )
         return self._obj
 
@@ -1339,7 +1337,7 @@ class DataFrameChecks:
         self,
         fn: Callable = lambda df: df,
         subset: Union[str, List, None] = None,
-        check_name: Union[str, None] = None,
+        msg: Union[str, None] = None,
         **kwargs: Any,
     ) -> pd.DataFrame:
         """Displays the number of duplicated rows in a DataFrame, without modifying the DataFrame itself.
@@ -1358,7 +1356,7 @@ class DataFrameChecks:
         Args:
             fn: An optional lambda function to apply to the DataFrame before counting the number of duplicates. Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before counting duplicate rows. Applied after fn.
-            check_name: An optional name for the check, to be printed as preface to the result.
+            msg: An optional name for the check, to be printed as preface to the result.
             **kwargs: Optional, additional arguments that are accepted by Pandas duplicated() method.
 
         Returns:
@@ -1369,8 +1367,8 @@ class DataFrameChecks:
             check_fn=lambda df: df.duplicated(**kwargs).sum(),
             modify_fn=fn,
             subset=subset,
-            check_name=check_name
-            if check_name
+            msg=msg
+            if msg
             else f"👯‍♂️ Rows with duplication in '{subset}'"
             if subset
             else "👯‍♂️ Duplicated rows",
@@ -1382,7 +1380,7 @@ class DataFrameChecks:
         fn: Callable = lambda df: df,
         subset: Union[str, List, None] = None,
         by_column: bool = True,
-        check_name: Union[str, None] = "👻 Rows with NaNs",
+        msg: Union[str, None] = "👻 Rows with NaNs",
     ) -> pd.DataFrame:
         """Displays the number of rows with null values in a DataFrame, without modifying the DataFrame itself.
 
@@ -1407,7 +1405,7 @@ class DataFrameChecks:
             fn: An optional lambda function to apply to the DataFrame before counting the number of rows with a null. Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before counting nulls.
             by_column: If True, count null values with each column separately. If False, count rows with a null value in any column. Applied after fn.
-            check_name: An optional name for the check, to be printed as preface to the result.
+            msg: An optional name for the check, to be printed as preface to the result.
 
         Returns:
             The original DataFrame, unchanged.
@@ -1427,15 +1425,13 @@ class DataFrameChecks:
         ):  # Report result as a pandas object
             _check_data(
                 na_counts,
-                check_name=f"👻 Rows with NaNs in {subset}"
-                if subset and not check_name
-                else check_name,
+                msg=f"👻 Rows with NaNs in {subset}" if subset and not msg else msg,
             )
         else:  # Report on one line
             _display_line(
                 (f"👻 Rows with NaNs in {subset}: {na_counts} out of {data.shape[0]}")
-                if subset and not check_name
-                else f"{check_name}: {na_counts}"
+                if subset and not msg
+                else f"{msg}: {na_counts}"
             )
         return self._obj
 
@@ -1443,7 +1439,7 @@ class DataFrameChecks:
         self,
         fn: Callable = lambda df: df,
         subset: Union[str, List, None] = None,
-        check_name: Union[str, None] = "☰ Rows",
+        msg: Union[str, None] = "☰ Rows",
     ) -> pd.DataFrame:
         """Displays the number of rows in a DataFrame, without modifying the DataFrame itself.
 
@@ -1458,7 +1454,7 @@ class DataFrameChecks:
         Args:
             fn: An optional lambda function to apply to the DataFrame before counting the number of rows. Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string name of one column to limit which columns are considered when counting rows. Applied after fn.
-            check_name: An optional name for the check, to be printed as preface to the result.
+            msg: An optional name for the check, to be printed as preface to the result.
 
         Returns:
             The original DataFrame, unchanged.
@@ -1468,7 +1464,7 @@ class DataFrameChecks:
             check_fn=lambda df: df.shape[0],
             modify_fn=fn,
             subset=subset,
-            check_name=check_name,
+            msg=msg,
         )
         return self._obj
 
@@ -1478,7 +1474,7 @@ class DataFrameChecks:
         subset: Union[str, List, None] = None,
         across_columns: bool = False,
         fn: Callable = lambda df: df,
-        check_name: Union[str, None] = None,
+        msg: Union[str, None] = None,
         **kwargs: Any,
     ) -> pd.DataFrame:
         """Displays the number of unique values in a Series or unique combinations of rows in a DataFrame, without modifying the DataFrame itself.
@@ -1505,7 +1501,7 @@ class DataFrameChecks:
                 - count the unique values in each column separately (False), the standard Pandas DataFrame nunique()
                 - count the unique combinations of rows across those columns (True) or
             fn: An optional lambda function to apply to the DataFrame before running Pandas nunique(). Example: `lambda df: df.shape[0]>10`. Applied before subset.
-            check_name: An optional name for the check, to be printed as preface to the result.
+            msg: An optional name for the check, to be printed as preface to the result.
             **kwargs: Optional, additional arguments that are accepted by Pandas nunique() method(s)
 
         Returns:
@@ -1524,19 +1520,19 @@ class DataFrameChecks:
 
             data_modified = _apply_modifications(self._obj, fn=fn, subset=subset)
 
-            if not check_name:
+            if not msg:
                 if subset:
                     if isinstance(subset, str):
-                        check_name = f"🌟 Unique values in '{subset}'"
+                        msg = f"🌟 Unique values in '{subset}'"
                     elif across_columns:
-                        check_name = f"🌟 Unique rows across {subset}"
+                        msg = f"🌟 Unique rows across {subset}"
                     else:
-                        check_name = f"🌟 Unique values in {subset}"
+                        msg = f"🌟 Unique values in {subset}"
                 else:
                     if across_columns:
-                        check_name = "🌟 Unique rows across all columns"
+                        msg = "🌟 Unique rows across all columns"
                     else:
-                        check_name = "🌟 Unique values"
+                        msg = "🌟 Unique values"
 
 
             if not across_columns:
@@ -1546,7 +1542,7 @@ class DataFrameChecks:
                     data_modified,
                     check_fn=lambda data: data.nunique(**kwargs),
                     modify_fn=fn,
-                    check_name=check_name,
+                    msg=msg,
                 )  # fmt: skip
             else:
                 # Count the number of unique rows considering values in multiple columns
@@ -1557,7 +1553,7 @@ class DataFrameChecks:
                 (
                     data_modified
                     .drop_duplicates()
-                    .check.nrows(check_name=check_name)
+                    .check.nrows(msg=msg)
                 )  # fmt: skip
         return self._obj
 
@@ -1565,7 +1561,7 @@ class DataFrameChecks:
         self,
         fn: Callable = lambda df: df,
         subset: Union[str, List, None] = None,
-        check_name: Union[str, None] = "",
+        msg: Union[str, None] = "",
         **kwargs: Any,
     ) -> pd.DataFrame:
         """Displays a plot of the DataFrame, without modifying the DataFrame itself.
@@ -1583,7 +1579,7 @@ class DataFrameChecks:
         Args:
             fn: An optional lambda function to apply to the DataFrame before running Pandas plot(). Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string name of one column to limit which columns are plotted. Applied after fn.
-            check_name: An optional title for the plot.
+            msg: An optional title for the plot.
             **kwargs: Optional, additional arguments that are accepted by Pandas plot() method.
 
         Returns:
@@ -1592,14 +1588,12 @@ class DataFrameChecks:
         Note:
             Plots are only displayed when code is run in IPython/Jupyter, not in terminal.
 
-            If you pass a 'title' kwarg, it becomes the plot title, overriding check_name
+            If you pass a 'title' kwarg, it becomes the plot title, overriding msg
         """
 
         # Only display plot if in IPython/Jupyter. Or we'd just print its title.
         if get_mode()["enable_checks"] and not pd.core.config_init.is_terminal():
-            _display_plot_title(
-                check_name if "title" not in kwargs else kwargs["title"]
-            )
+            _display_plot_title(msg if "title" not in kwargs else kwargs["title"])
             _ = _apply_modifications(self._obj, fn, subset).plot(**kwargs)
             _display_plot()
         return self._obj
@@ -1609,7 +1603,7 @@ class DataFrameChecks:
         object: Any = None,
         fn: Callable = lambda df: df,
         subset: Union[str, List, None] = None,
-        check_name: Union[str, None] = None,
+        msg: Union[str, None] = None,
         max_rows: int = 10,
     ) -> pd.DataFrame:
         """Displays text, another object, or (by default) the current DataFrame's head. Does not modify the DataFrame itself.
@@ -1627,7 +1621,7 @@ class DataFrameChecks:
                 (
                     iris
                     ...
-                    .check.print(fn=lambda df: df.query("sepal_width<0"), check_name="Rows with negative sepal_width")
+                    .check.print(fn=lambda df: df.query("sepal_width<0"), msg="Rows with negative sepal_width")
                 )
             ```
 
@@ -1635,7 +1629,7 @@ class DataFrameChecks:
             object: Object to print. Can be anything printable: str, int, list, another DataFrame, etc. If None, print the DataFrame's head (with `max_rows` rows).
             fn: An optional lambda function to apply to the DataFrame before printing `object`. Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string name of one column to limit which columns are printed. Applied after fn.
-            check_name: An optional name for the check, to be printed as preface to the result.
+            msg: An optional name for the check, to be printed as preface to the result.
             max_rows: Maximum number of rows to print if object=None.
 
         Returns:
@@ -1646,7 +1640,7 @@ class DataFrameChecks:
             check_fn=lambda data: data if object else data.head(max_rows),
             modify_fn=fn,
             subset=subset,
-            check_name=check_name,
+            msg=msg,
         )
         return self._obj
 
@@ -1779,7 +1773,7 @@ class DataFrameChecks:
         self,
         fn: Callable = lambda df: df,
         subset: Union[str, List, None] = None,
-        check_name: Union[str, None] = "📐 Shape",
+        msg: Union[str, None] = "📐 Shape",
     ) -> pd.DataFrame:
         """Displays the Dataframe's dimensions, without modifying the DataFrame itself.
 
@@ -1788,14 +1782,14 @@ class DataFrameChecks:
                 (
                     iris
                     .check.shape()
-                    .check.shape(fn=lambda df: df.query("sepal_length<5"), check_name="Shape of DataFrame subgroup with sepal_length<5")
+                    .check.shape(fn=lambda df: df.query("sepal_length<5"), msg="Shape of DataFrame subgroup with sepal_length<5")
                 )
             ```
 
         Args:
             fn: An optional lambda function to apply to the DataFrame before running Pandas `shape`. Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string name of one column to limit which columns are considered when printing the shape. Applied after fn.
-            check_name: An optional name for the check, to be printed as preface to the result.
+            msg: An optional name for the check, to be printed as preface to the result.
 
         Returns:
             The original DataFrame, unchanged.
@@ -1808,7 +1802,7 @@ class DataFrameChecks:
             check_fn=lambda df: df.shape,
             modify_fn=fn,
             subset=subset,
-            check_name=check_name,
+            msg=msg,
         )
         return self._obj
 
@@ -1817,7 +1811,7 @@ class DataFrameChecks:
         n: int = 5,
         fn: Callable = lambda df: df,
         subset: Union[str, List, None] = None,
-        check_name: Union[str, None] = None,
+        msg: Union[str, None] = None,
     ) -> pd.DataFrame:
         """Displays the last n rows of the DataFrame, without modifying the DataFrame itself.
 
@@ -1835,7 +1829,7 @@ class DataFrameChecks:
             n: Number of rows to show.
             fn: An optional lambda function to apply to the DataFrame before running Pandas tail(). Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string name of one column to limit which columns are displayed. Applied after fn.
-            check_name: An optional name for the check, to be printed as preface to the result.
+            msg: An optional name for the check, to be printed as preface to the result.
 
         Returns:
             The original DataFrame, unchanged.
@@ -1845,7 +1839,7 @@ class DataFrameChecks:
             check_fn=lambda df: df.tail(n),
             modify_fn=fn,
             subset=subset,
-            check_name=check_name if check_name else f"⬇️ Last {n} rows",
+            msg=msg if msg else f"⬇️ Last {n} rows",
         )
         return self._obj
 
@@ -1853,7 +1847,7 @@ class DataFrameChecks:
         self,
         column: str,
         fn: Callable = lambda df: df,
-        check_name: Union[str, None] = None,
+        msg: Union[str, None] = None,
     ) -> pd.DataFrame:
         """Displays the unique values in a column, without modifying the DataFrame itself.
 
@@ -1871,7 +1865,7 @@ class DataFrameChecks:
         Args:
             column: Column to check for unique values.
             fn: An optional lambda function to apply to the DataFrame before calling Pandas unique(). Example: `lambda df: df.shape[0]>10`. Applied before subset.
-            check_name: An optional name for the check, to be printed as preface to the result.
+            msg: An optional name for the check, to be printed as preface to the result.
 
         Returns:
             The original DataFrame, unchanged.
@@ -1887,7 +1881,7 @@ class DataFrameChecks:
                 # Use SeriesChecks method
                 .check.unique(
                     fn=lambda s: s,  # Identify function
-                    check_name=check_name,
+                    msg=msg,
                 )
             )  # fmt: skip
         return self._obj
@@ -1897,7 +1891,7 @@ class DataFrameChecks:
         column: str,
         fn: Callable = lambda df: df,
         max_rows: int = 10,
-        check_name: Union[str, None] = None,
+        msg: Union[str, None] = None,
         **kwargs: Any,
     ) -> pd.DataFrame:
         """Displays the value counts for a column, without modifying the DataFrame itself.
@@ -1916,7 +1910,7 @@ class DataFrameChecks:
             column: Column to check for value counts.
             max_rows: Maximum number of rows to show in the value counts.
             fn: An optional lambda function to apply to the DataFrame before running Pandas value_counts(). Example: `lambda df: df.shape[0]>10`. Applied before subset.
-            check_name: An optional name for the check, to be printed as preface to the result.
+            msg: An optional name for the check, to be printed as preface to the result.
             **kwargs: Optional, additional arguments that are accepted by Pandas value_counts() method.
 
         Returns:
@@ -1933,7 +1927,7 @@ class DataFrameChecks:
                 .check.value_counts(
                     max_rows=max_rows,
                     fn=lambda s: s,  # Identity function
-                    check_name=check_name,
+                    msg=msg,
                     **kwargs,
                 )
             )  # fmt: skip

--- a/pandas_checks/DataFrameChecks.py
+++ b/pandas_checks/DataFrameChecks.py
@@ -1558,8 +1558,8 @@ class DataFrameChecks:
 
     def plot(
         self,
-        fn: Callable = lambda df: df,
         subset: Union[str, List, None] = None,
+        fn: Callable = lambda df: df,
         msg: Union[str, None] = "",
         **kwargs: Any,
     ) -> pd.DataFrame:
@@ -1576,8 +1576,8 @@ class DataFrameChecks:
             ```
 
         Args:
-            fn: An optional lambda function to apply to the DataFrame before running Pandas plot(). Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string name of one column to limit which columns are plotted. Applied after fn.
+            fn: An optional lambda function to apply to the DataFrame before running Pandas plot(). Example: `lambda df: df.shape[0]>10`. Applied before subset.
             msg: An optional title for the plot.
             **kwargs: Optional, additional arguments that are accepted by Pandas plot() method.
 

--- a/pandas_checks/DataFrameChecks.py
+++ b/pandas_checks/DataFrameChecks.py
@@ -1302,9 +1302,9 @@ class DataFrameChecks:
 
     def ncols(
         self,
+        msg: Union[str, None] = "🏛️ Columns",
         fn: Callable = lambda df: df,
         subset: Union[str, List, None] = None,
-        msg: Union[str, None] = "🏛️ Columns",
     ) -> pd.DataFrame:
         """Displays the number of columns in a DataFrame, without modifying the DataFrame itself.
 
@@ -1317,9 +1317,9 @@ class DataFrameChecks:
             ```
 
         Args:
+            msg: Optionally customize the text displayed before the result of the check.
             fn: An optional lambda function to apply to the DataFrame before counting the number of columns. Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before counting the number of columns. Applied after fn.
-            msg: Optionally customize the text displayed before the result of the check.
 
         Returns:
             The original DataFrame, unchanged.
@@ -1437,9 +1437,9 @@ class DataFrameChecks:
 
     def nrows(
         self,
+        msg: Union[str, None] = "☰ Rows",
         fn: Callable = lambda df: df,
         subset: Union[str, List, None] = None,
-        msg: Union[str, None] = "☰ Rows",
     ) -> pd.DataFrame:
         """Displays the number of rows in a DataFrame, without modifying the DataFrame itself.
 
@@ -1452,9 +1452,9 @@ class DataFrameChecks:
             ```
 
         Args:
+            msg: Optionally customize the text displayed before the result of the check.
             fn: An optional lambda function to apply to the DataFrame before counting the number of rows. Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string name of one column to limit which columns are considered when counting rows. Applied after fn.
-            msg: Optionally customize the text displayed before the result of the check.
 
         Returns:
             The original DataFrame, unchanged.
@@ -1771,9 +1771,9 @@ class DataFrameChecks:
 
     def shape(
         self,
+        msg: Union[str, None] = "📐 Shape",
         fn: Callable = lambda df: df,
         subset: Union[str, List, None] = None,
-        msg: Union[str, None] = "📐 Shape",
     ) -> pd.DataFrame:
         """Displays the Dataframe's dimensions, without modifying the DataFrame itself.
 
@@ -1782,14 +1782,14 @@ class DataFrameChecks:
                 (
                     iris
                     .check.shape()
-                    .check.shape(fn=lambda df: df.query("sepal_length<5"), msg="Shape of DataFrame subgroup with sepal_length<5")
+                    .check.shape(msg="Shape of DataFrame subgroup with sepal_length<5", fn=lambda df: df.query("sepal_length<5"))
                 )
             ```
 
         Args:
+            msg: Optionally customize the text displayed before the result of the check.
             fn: An optional lambda function to apply to the DataFrame before running Pandas `shape`. Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string name of one column to limit which columns are considered when printing the shape. Applied after fn.
-            msg: Optionally customize the text displayed before the result of the check.
 
         Returns:
             The original DataFrame, unchanged.

--- a/pandas_checks/DataFrameChecks.py
+++ b/pandas_checks/DataFrameChecks.py
@@ -1302,9 +1302,9 @@ class DataFrameChecks:
 
     def ncols(
         self,
+        msg: Union[str, None] = "🏛️ Columns",
         fn: Callable = lambda df: df,
         subset: Union[str, List, None] = None,
-        msg: Union[str, None] = "🏛️ Columns",
     ) -> pd.DataFrame:
         """Displays the number of columns in a DataFrame, without modifying the DataFrame itself.
 
@@ -1317,9 +1317,9 @@ class DataFrameChecks:
             ```
 
         Args:
+            msg: Optionally customize the text displayed before the result of the check.
             fn: An optional lambda function to apply to the DataFrame before counting the number of columns. Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before counting the number of columns. Applied after fn.
-            msg: Optionally customize the text displayed before the result of the check.
 
         Returns:
             The original DataFrame, unchanged.
@@ -1437,9 +1437,9 @@ class DataFrameChecks:
 
     def nrows(
         self,
+        msg: Union[str, None] = "☰ Rows",
         fn: Callable = lambda df: df,
         subset: Union[str, List, None] = None,
-        msg: Union[str, None] = "☰ Rows",
     ) -> pd.DataFrame:
         """Displays the number of rows in a DataFrame, without modifying the DataFrame itself.
 
@@ -1452,9 +1452,9 @@ class DataFrameChecks:
             ```
 
         Args:
+            msg: Optionally customize the text displayed before the result of the check.
             fn: An optional lambda function to apply to the DataFrame before counting the number of rows. Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string name of one column to limit which columns are considered when counting rows. Applied after fn.
-            msg: Optionally customize the text displayed before the result of the check.
 
         Returns:
             The original DataFrame, unchanged.
@@ -1765,9 +1765,9 @@ class DataFrameChecks:
 
     def shape(
         self,
+        msg: Union[str, None] = "📐 Shape",
         fn: Callable = lambda df: df,
         subset: Union[str, List, None] = None,
-        msg: Union[str, None] = "📐 Shape",
     ) -> pd.DataFrame:
         """Displays the Dataframe's dimensions, without modifying the DataFrame itself.
 
@@ -1776,14 +1776,14 @@ class DataFrameChecks:
                 (
                     iris
                     .check.shape()
-                    .check.shape(fn=lambda df: df.query("sepal_length<5"), msg="Shape of DataFrame subgroup with sepal_length<5")
+                    .check.shape(msg="Shape of DataFrame subgroup with sepal_length<5", fn=lambda df: df.query("sepal_length<5"))
                 )
             ```
 
         Args:
+            msg: Optionally customize the text displayed before the result of the check.
             fn: An optional lambda function to apply to the DataFrame before running Pandas `shape`. Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string name of one column to limit which columns are considered when printing the shape. Applied after fn.
-            msg: Optionally customize the text displayed before the result of the check.
 
         Returns:
             The original DataFrame, unchanged.

--- a/pandas_checks/DataFrameChecks.py
+++ b/pandas_checks/DataFrameChecks.py
@@ -1168,8 +1168,8 @@ class DataFrameChecks:
 
     def hist(
         self,
-        fn: Callable = lambda df: df,
         subset: Union[str, List, None] = [],
+        fn: Callable = lambda df: df,
         msg: Union[str, None] = None,
         **kwargs: Any,
     ) -> pd.DataFrame:
@@ -1184,17 +1184,17 @@ class DataFrameChecks:
                 (
                     iris
                     # Show one histogram
-                    .check.hist(column="sepal_length")
-                    # Show two histogram
-                    .check.hist(subset=["petal_length", "petal_width"])
+                    .check.hist("sepal_length")
+                    # Show two histograms
+                    .check.hist(["petal_length", "petal_width"])
                 )
             ```
 
         Args:
-            fn: An optional lambda function to apply to the DataFrame before running Pandas hist(). Example: `lambda df: df.shape[0]>10`. Applied before subset.
             subset: An optional list of column names or a string to select a subset of columns before running Pandas hist(). Applied after fn.
+            fn: An optional lambda function to apply to the DataFrame before running Pandas hist(). Example: `lambda df: df.shape[0]>10`. Applied before subset.
             msg: Optionally customize the text displayed before the result of the check.
-            **kwargs: Optional, additional arguments that are accepted by Pandas hist() method, such as `column`.
+            **kwargs: Optional, additional arguments that are accepted by Pandas hist() method.
 
         Returns:
             The original DataFrame, unchanged.
@@ -1215,7 +1215,7 @@ class DataFrameChecks:
         # Only display if in IPython/Jupyter, or we'd just print the title
         if get_mode()["enable_checks"] and not pd.core.config_init.is_terminal():
             _display_plot_title(msg)
-            _ = _apply_modifications(self._obj, fn, subset).hist(**kwargs)
+            _ = _apply_modifications(self._obj, fn=fn, subset=subset).hist(**kwargs)
             _display_plot()
         return self._obj
 
@@ -1533,7 +1533,6 @@ class DataFrameChecks:
                         msg = "🌟 Unique rows across all columns"
                     else:
                         msg = "🌟 Unique values"
-
 
             if not across_columns:
                 # Run standard Pandas nunique()

--- a/pandas_checks/SeriesChecks.py
+++ b/pandas_checks/SeriesChecks.py
@@ -870,7 +870,7 @@ class SeriesChecks:
     ) -> pd.Series:
         """Displays descriptive statistics about a Series, without modifying the Series itself.
 
-        See Pandas docs for [describe()](https://pandas.pydata.org/docs/reference/api/pandas.Series.describe.html) for additional usage information, including more configuration options you can pass to this Pandas Checks method.
+        See Pandas docs for [describe()](https://pandas.pydata.org/docs/reference/api/pandas.Series.describe.html) for additional usage information, including more options you can pass to this Pandas Checks method.
 
         Example:
             ```python
@@ -1065,7 +1065,7 @@ class SeriesChecks:
     ) -> pd.Series:
         """Displays a histogram for the Series's distribution, without modifying the Series itself.
 
-        See Pandas docs for [hist()](https://pandas.pydata.org/docs/reference/api/pandas.Series.hist.html) for additional usage information, including more configuration options you can pass to this Pandas Checks method.
+        See Pandas docs for [hist()](https://pandas.pydata.org/docs/reference/api/pandas.Series.hist.html) for additional usage information, including more options you can pass to this Pandas Checks method.
 
         Example:
             ```python
@@ -1101,7 +1101,7 @@ class SeriesChecks:
     ) -> pd.Series:
         """Displays summary information about a Series, without modifying the Series itself.
 
-        See Pandas docs for [info()](https://pandas.pydata.org/docs/reference/api/pandas.Series.info.html) for additional usage information, including more configuration options you can pass to this Pandas Checks method.
+        See Pandas docs for [info()](https://pandas.pydata.org/docs/reference/api/pandas.Series.info.html) for additional usage information, including more options you can pass to this Pandas Checks method.
 
         Example:
             ```python
@@ -1134,7 +1134,7 @@ class SeriesChecks:
     ) -> pd.Series:
         """Displays the memory footprint of a Series, without modifying the Series itself.
 
-        See Pandas docs for [memory_usage()](https://pandas.pydata.org/docs/reference/api/pandas.Series.memory_usage.html) for additional usage information, including more configuration options you can pass to this Pandas Checks method.
+        See Pandas docs for [memory_usage()](https://pandas.pydata.org/docs/reference/api/pandas.Series.memory_usage.html) for additional usage information, including more options you can pass to this Pandas Checks method.
 
         Example:
             ```python
@@ -1170,7 +1170,7 @@ class SeriesChecks:
     ) -> pd.Series:
         """Displays the number of duplicated rows in the Series, without modifying the Series itself.
 
-        See Pandas docs for [duplicated()](https://pandas.pydata.org/docs/reference/api/pandas.Series.duplicated.html) for additional usage information, including more configuration options (the `keep` argument) you can pass to this Pandas Checks method.
+        See Pandas docs for [duplicated()](https://pandas.pydata.org/docs/reference/api/pandas.Series.duplicated.html) for additional usage information, including more options (the `keep` argument) you can pass to this Pandas Checks method.
 
         Example:
             ```python
@@ -1263,7 +1263,7 @@ class SeriesChecks:
     ) -> pd.Series:
         """Displays the number of unique rows in a Series, without modifying the Series itself.
 
-        See Pandas docs for [nunique()](https://pandas.pydata.org/docs/reference/api/pandas.Series.nunique.html) for additional usage information, including more configuration options (the `dropna` argument) you can pass to this Pandas Checks method.
+        See Pandas docs for [nunique()](https://pandas.pydata.org/docs/reference/api/pandas.Series.nunique.html) for additional usage information, including more options (the `dropna` argument) you can pass to this Pandas Checks method.
 
         Example:
             ```python
@@ -1303,7 +1303,7 @@ class SeriesChecks:
     ) -> pd.Series:
         """Displays a plot of the Series, without modifying the Series itself.
 
-        See Pandas docs for [plot()](https://pandas.pydata.org/docs/reference/api/pandas.Series.plot.html) for additional usage information, including more configuration options you can pass to this Pandas Checks method.
+        See Pandas docs for [plot()](https://pandas.pydata.org/docs/reference/api/pandas.Series.plot.html) for additional usage information, including more options you can pass to this Pandas Checks method.
 
         Example:
             ```python
@@ -1615,7 +1615,7 @@ class SeriesChecks:
     ) -> pd.Series:
         """Displays the value counts for a Series, without modifying the Series itself.
 
-        See Pandas docs for [value_counts()](https://pandas.pydata.org/docs/reference/api/pandas.Series.value_counts.html) for additional usage information, including more configuration options you can pass to this Pandas Checks method.
+        See Pandas docs for [value_counts()](https://pandas.pydata.org/docs/reference/api/pandas.Series.value_counts.html) for additional usage information, including more options you can pass to this Pandas Checks method.
 
         Example:
             ```python
@@ -1668,7 +1668,7 @@ class SeriesChecks:
             - .tsv # Tab-separated data file
             - .xlsx
 
-        This functions uses the corresponding Pandas export function such as to_csv() and to_feather(). See [Pandas docs for those corresponding export functions](https://pandas.pydata.org/docs/reference/io.html) for additional usage information, including more configuration options you can pass to this Pandas Checks method.
+        This functions uses the corresponding Pandas export function such as to_csv() and to_feather(). See [Pandas docs for those corresponding export functions](https://pandas.pydata.org/docs/reference/io.html) for additional usage information, including more options you can pass to this Pandas Checks method.
 
         Note:
             Exporting to some formats such as Excel, Feather, and Parquet may require you to install additional packages.

--- a/pandas_checks/SeriesChecks.py
+++ b/pandas_checks/SeriesChecks.py
@@ -1228,8 +1228,8 @@ class SeriesChecks:
 
     def nrows(
         self,
-        fn: Callable = lambda s: s,
         msg: Union[str, None] = "☰ Rows",
+        fn: Callable = lambda s: s,
     ) -> pd.Series:
         """Displays the number of rows in a Series, without modifying the Series itself.
 
@@ -1243,8 +1243,8 @@ class SeriesChecks:
             ```
 
         Args:
-            fn: An optional lambda function to apply to the Series before counting the number of rows. Example: `lambda s: s.dropna()`.
             msg: Optionally customize the text displayed before the result of the check.
+            fn: An optional lambda function to apply to the Series before counting the number of rows. Example: `lambda s: s.dropna()`.
 
         Returns:
             The original Series, unchanged.
@@ -1500,8 +1500,8 @@ class SeriesChecks:
 
     def shape(
         self,
-        fn: Callable = lambda s: s,
         msg: Union[str, None] = "📐 Shape",
+        fn: Callable = lambda s: s,
     ) -> pd.Series:
         """Displays the Series's dimensions, without modifying the Series itself.
 
@@ -1511,13 +1511,13 @@ class SeriesChecks:
                 iris
                 ["sepal_width"]
                 .check.shape()
-                .check.shape(fn=lambda s: s[s<5]), msg="Shape of sepal_width series with values <5")
+                .check.shape(msg="Shape of sepal_width series with values <5", fn=lambda s: s[s<5]))
             )
             ```
 
         Args:
-            fn: An optional lambda function to apply to the Series before running Pandas `shape`. Example: `lambda s: s.dropna()`.
             msg: Optionally customize the text displayed before the result of the check.
+            fn: An optional lambda function to apply to the Series before running Pandas `shape`. Example: `lambda s: s.dropna()`.
 
         Returns:
             The original Series, unchanged.

--- a/pandas_checks/SeriesChecks.py
+++ b/pandas_checks/SeriesChecks.py
@@ -1330,7 +1330,7 @@ class SeriesChecks:
         """
         (
             pd.DataFrame(_apply_modifications(self._obj, fn))
-            .check.plot(fn, msg=msg, **kwargs)
+            .check.plot(fn=fn, msg=msg, **kwargs)
         )  # fmt: skip
         return self._obj
 

--- a/pandas_checks/SeriesChecks.py
+++ b/pandas_checks/SeriesChecks.py
@@ -865,7 +865,7 @@ class SeriesChecks:
     def describe(
         self,
         fn: Callable = lambda s: s,
-        check_name: Union[str, None] = "📏 Distribution",
+        msg: Union[str, None] = "📏 Distribution",
         **kwargs: Any,
     ) -> pd.Series:
         """Displays descriptive statistics about a Series, without modifying the Series itself.
@@ -883,7 +883,7 @@ class SeriesChecks:
 
         Args:
             fn: An optional lambda function to apply to the Series before running Pandas describe(). Example: `lambda s: s.dropna()`.
-            check_name: An optional name for the check to preface the result with.
+            msg: An optional name for the check to preface the result with.
             **kwargs: Optional, additional arguments that are accepted by Pandas describe() method.
 
         Returns:
@@ -891,7 +891,7 @@ class SeriesChecks:
         """
         (
             pd.DataFrame(_apply_modifications(self._obj, fn))
-            .check.describe(check_name=check_name, **kwargs)
+            .check.describe(msg=msg, **kwargs)
         )  # fmt: skip
         return self._obj
 
@@ -921,7 +921,7 @@ class SeriesChecks:
     def dtype(
         self,
         fn: Callable = lambda s: s,
-        check_name: Union[str, None] = "🗂️ Data type",
+        msg: Union[str, None] = "🗂️ Data type",
     ) -> pd.Series:
         """Displays the data type of a Series, without modifying the Series itself.
 
@@ -936,7 +936,7 @@ class SeriesChecks:
 
         Args:
             fn: An optional lambda function to apply to the Series before running Pandas dtype. Example: `lambda s: s.dropna()`.
-            check_name: An optional name for the check to preface the result with.
+            msg: An optional name for the check to preface the result with.
 
         Returns:
             The original Series, unchanged.
@@ -945,7 +945,7 @@ class SeriesChecks:
             self._obj,
             check_fn=lambda s: s.dtype,
             modify_fn=fn,
-            check_name=check_name,
+            msg=msg,
         )
         return self._obj
 
@@ -975,7 +975,7 @@ class SeriesChecks:
     def function(
         self,
         fn: Callable = lambda s: s,
-        check_name: Union[str, None] = None,
+        msg: Union[str, None] = None,
     ) -> pd.Series:
         """Applies an arbitrary function on a Series and shows the result, without modifying the Series itself.
 
@@ -983,24 +983,22 @@ class SeriesChecks:
             ```python
             (
                 iris
-                .check.function(fn=lambda s: s.shape[0]>10, check_name='Has at least 10 rows?')
+                .check.function(fn=lambda s: s.shape[0]>10, msg='Has at least 10 rows?')
             )
             # Will return "True"
             ```
 
         Args:
             fn: The lambda function to apply to the Series. Example: `lambda s: s.dropna()`.
-            check_name: An optional name for the check to preface the result with.
+            msg: An optional name for the check to preface the result with.
 
         Returns:
             The original Series, unchanged.
         """
-        _check_data(self._obj, modify_fn=fn, check_name=check_name)
+        _check_data(self._obj, modify_fn=fn, msg=msg)
         return self._obj
 
-    def get_mode(
-        self, check_name: Union[str, None] = "⚙️ Pandas Checks mode"
-    ) -> pd.Series:
+    def get_mode(self, msg: Union[str, None] = "⚙️ Pandas Checks mode") -> pd.Series:
         """Displays the current values of Pandas Checks global options enable_checks and enable_asserts. Does not modify the Series itself.
 
         Example:
@@ -1015,14 +1013,14 @@ class SeriesChecks:
             ```
 
         Args:
-            check_name: An optional name for the check. Will be used as a preface the printed result.
+            msg: An optional name for the check. Will be used as a preface the printed result.
 
         Returns:
             The original Series, unchanged.
         """
         (
             pd.DataFrame(self._obj)
-            .check.get_mode(check_name=check_name)
+            .check.get_mode(msg=msg)
         )  # fmt: skip
         return self._obj
 
@@ -1030,7 +1028,7 @@ class SeriesChecks:
         self,
         n: int = 5,
         fn: Callable = lambda s: s,
-        check_name: Union[str, None] = None,
+        msg: Union[str, None] = None,
     ) -> pd.Series:
         """Displays the first n rows of a Series, without modifying the Series itself.
 
@@ -1048,21 +1046,21 @@ class SeriesChecks:
         Args:
             n: The number of rows to display.
             fn: An optional lambda function to apply to the Series before running Pandas head(). Example: `lambda s: s.dropna()`.
-            check_name: An optional name for the check, to be printed as preface to the result.
+            msg: An optional name for the check, to be printed as preface to the result.
 
         Returns:
             The original Series, unchanged.
         """
         (
             pd.DataFrame(_apply_modifications(self._obj, fn))
-            .check.head(n=n, check_name=check_name)
+            .check.head(n=n, msg=msg)
         )  # fmt: skip
         return self._obj
 
     def hist(
         self,
         fn: Callable = lambda s: s,
-        check_name: Union[str, None] = None,
+        msg: Union[str, None] = None,
         **kwargs: Any,
     ) -> pd.Series:
         """Displays a histogram for the Series's distribution, without modifying the Series itself.
@@ -1080,7 +1078,7 @@ class SeriesChecks:
 
         Args:
             fn: An optional lambda function to apply to the Series before running Pandas head(). Example: `lambda s: s.dropna()`.
-            check_name: An optional name for the check, to be printed as preface to the result.
+            msg: An optional name for the check, to be printed as preface to the result.
             **kwargs: Optional, additional arguments that are accepted by Pandas hist() method.
 
         Returns:
@@ -1091,14 +1089,14 @@ class SeriesChecks:
         """
         (
             pd.DataFrame(_apply_modifications(self._obj, fn))
-            .check.hist(check_name=check_name, subset=[], **kwargs)
+            .check.hist(msg=msg, subset=[], **kwargs)
         )  # fmt: skip
         return self._obj
 
     def info(
         self,
         fn: Callable = lambda s: s,
-        check_name: Union[str, None] = "ℹ️ Series info",
+        msg: Union[str, None] = "ℹ️ Series info",
         **kwargs: Any,
     ) -> pd.Series:
         """Displays summary information about a Series, without modifying the Series itself.
@@ -1116,22 +1114,22 @@ class SeriesChecks:
 
         Args:
             fn: An optional lambda function to apply to the Series before running Pandas info(). Example: `lambda s: s.dropna()`.
-            check_name: An optional name for the check, to be printed as preface to the result.
+            msg: An optional name for the check, to be printed as preface to the result.
             **kwargs: Optional, additional arguments that are accepted by Pandas info() method.
 
         Returns:
             The original Series, unchanged.
         """
         if get_mode()["enable_checks"]:
-            if check_name:
-                _display_table_title(check_name)
+            if msg:
+                _display_table_title(msg)
             _apply_modifications(self._obj, fn).info(**kwargs)
         return self._obj
 
     def memory_usage(
         self,
         fn: Callable = lambda s: s,
-        check_name: Union[str, None] = "💾 Memory usage",
+        msg: Union[str, None] = "💾 Memory usage",
         **kwargs: Any,
     ) -> pd.Series:
         """Displays the memory footprint of a Series, without modifying the Series itself.
@@ -1149,7 +1147,7 @@ class SeriesChecks:
 
         Args:
             fn: An optional lambda function to apply to the Series before running Pandas memory_usage(). Example: `lambda s: s.dropna()`.
-            check_name: An optional name for the check, to be printed as preface to the result.
+            msg: An optional name for the check, to be printed as preface to the result.
             **kwargs: Optional, additional arguments that are accepted by Pandas memory_usage() method.
 
         Returns:
@@ -1160,14 +1158,14 @@ class SeriesChecks:
         """
         (
             pd.DataFrame(_apply_modifications(self._obj, fn))
-            .check.memory_usage(check_name=check_name, **kwargs)
+            .check.memory_usage(msg=msg, **kwargs)
         )  # fmt: skip
         return self._obj
 
     def ndups(
         self,
         fn: Callable = lambda s: s,
-        check_name: Union[str, None] = None,
+        msg: Union[str, None] = None,
         **kwargs: Any,
     ) -> pd.Series:
         """Displays the number of duplicated rows in the Series, without modifying the Series itself.
@@ -1185,7 +1183,7 @@ class SeriesChecks:
 
         Args:
             fn: An optional lambda function to apply to the Series before counting the number of duplicates. Example: `lambda s: s.dropna()`.
-            check_name: An optional name for the check, to be printed as preface to the result.
+            msg: An optional name for the check, to be printed as preface to the result.
             **kwargs: Optional, additional arguments that are accepted by Pandas duplicated() method.
 
         Returns:
@@ -1193,14 +1191,14 @@ class SeriesChecks:
         """
         (
             pd.DataFrame(_apply_modifications(self._obj, fn))
-            .check.ndups(fn, check_name=check_name, **kwargs)
+            .check.ndups(fn, msg=msg, **kwargs)
         )  # fmt: skip
         return self._obj
 
     def nnulls(
         self,
         fn: Callable = lambda s: s,
-        check_name: Union[str, None] = "👻 Rows with NaNs",
+        msg: Union[str, None] = "👻 Rows with NaNs",
     ) -> pd.Series:
         """Displays the number of rows with null values in the Series, without modifying the Series itself.
 
@@ -1217,21 +1215,21 @@ class SeriesChecks:
 
         Args:
             fn: An optional lambda function to apply to the Series before counting rows with nulls. Example: `lambda s: s.dropna()`.
-            check_name: An optional name for the check, to be printed as preface to the result.
+            msg: An optional name for the check, to be printed as preface to the result.
 
         Returns:
             The original Series, unchanged.
         """
         (
             pd.DataFrame(_apply_modifications(self._obj, fn))
-            .check.nnulls(by_column=False, check_name=check_name)
+            .check.nnulls(by_column=False, msg=msg)
         )  # fmt: skip
         return self._obj
 
     def nrows(
         self,
         fn: Callable = lambda s: s,
-        check_name: Union[str, None] = "☰ Rows",
+        msg: Union[str, None] = "☰ Rows",
     ) -> pd.Series:
         """Displays the number of rows in a Series, without modifying the Series itself.
 
@@ -1246,21 +1244,21 @@ class SeriesChecks:
 
         Args:
             fn: An optional lambda function to apply to the Series before counting the number of rows. Example: `lambda s: s.dropna()`.
-            check_name: An optional name for the check, to be printed as preface to the result.
+            msg: An optional name for the check, to be printed as preface to the result.
 
         Returns:
             The original Series, unchanged.
         """
         (
             pd.DataFrame(_apply_modifications(self._obj, fn))
-            .check.nrows(check_name=check_name)
+            .check.nrows(msg=msg)
         )  # fmt: skip
         return self._obj
 
     def nunique(
         self,
         fn: Callable = lambda s: s,
-        check_name: Union[str, None] = None,
+        msg: Union[str, None] = None,
         **kwargs: Any,
     ) -> pd.Series:
         """Displays the number of unique rows in a Series, without modifying the Series itself.
@@ -1278,29 +1276,29 @@ class SeriesChecks:
 
         Args:
             fn: An optional lambda function to apply to the Series before running Pandas nunique(). Example: `lambda s: s.dropna()`.
-            check_name: An optional name for the check, to be printed as preface to the result.
+            msg: An optional name for the check, to be printed as preface to the result.
             **kwargs: Optional, additional arguments that are accepted by Pandas nunique() method.
 
         Returns:
             The original Series, unchanged.
         """
-        if not check_name:
+        if not msg:
             if self._obj.name:
-                check_name = f"🌟 Unique values in '{self._obj.name}'"
+                msg = f"🌟 Unique values in '{self._obj.name}'"
             else:
-                check_name = "🌟 Unique values"
+                msg = "🌟 Unique values"
         _check_data(
             self._obj,
             check_fn=lambda s: s.nunique(**kwargs),
             modify_fn=fn,
-            check_name=check_name,
+            msg=msg,
         )
         return self._obj
 
     def plot(
         self,
         fn: Callable = lambda s: s,
-        check_name: Union[str, None] = "",
+        msg: Union[str, None] = "",
         **kwargs: Any,
     ) -> pd.Series:
         """Displays a plot of the Series, without modifying the Series itself.
@@ -1319,7 +1317,7 @@ class SeriesChecks:
 
         Args:
             fn: An optional lambda function to apply to the Series before running Pandas plot(). Example: `lambda s: s.dropna()`.
-            check_name: An optional title for the plot.
+            msg: An optional title for the plot.
             **kwargs: Optional, additional arguments that are accepted by Pandas plot() method.
 
         Returns:
@@ -1328,11 +1326,11 @@ class SeriesChecks:
         Note:
             Plots are only displayed when code is run in IPython/Jupyter, not in terminal.
 
-            If you pass a 'title' kwarg, it becomes the plot title, overriding check_name
+            If you pass a 'title' kwarg, it becomes the plot title, overriding msg
         """
         (
             pd.DataFrame(_apply_modifications(self._obj, fn))
-            .check.plot(fn, check_name=check_name, **kwargs)
+            .check.plot(fn, msg=msg, **kwargs)
         )  # fmt: skip
         return self._obj
 
@@ -1340,7 +1338,7 @@ class SeriesChecks:
         self,
         object: Any = None,  # Anything printable: str, int, list, DataFrame, etc
         fn: Callable = lambda s: s,
-        check_name: Union[str, None] = None,
+        msg: Union[str, None] = None,
         max_rows: int = 10,
     ) -> pd.Series:
         """Displays text, another object, or (by default) the current DataFrame's head. Does not modify the Series itself.
@@ -1356,14 +1354,14 @@ class SeriesChecks:
                 ...
 
                 # Inspect a Series, such as the interim result of data processing
-                .check.print(fn=lambda s: s[s<0], check_name="Negative values of sepal_width") # Will print those values if they exist
+                .check.print(fn=lambda s: s[s<0], msg="Negative values of sepal_width") # Will print those values if they exist
             )
             ```
 
         Args:
             object: Object to print. Can be anything printable: str, int, list, another DataFrame, etc. If None, print the Series's head (with `max_rows` rows).
             fn: An optional lambda function to apply to the Series before printing `object`. Example: `lambda s: s.dropna()`.
-            check_name: An optional name for the check, to be printed as preface to the result.
+            msg: An optional name for the check, to be printed as preface to the result.
             max_rows: Maximum number of rows to print if object=None.
 
         Returns:
@@ -1371,7 +1369,7 @@ class SeriesChecks:
         """
         (
             pd.DataFrame(_apply_modifications(self._obj, fn))
-            .check.print(object=object, check_name=check_name, max_rows=max_rows)
+            .check.print(object=object, msg=msg, max_rows=max_rows)
         )  # fmt: skip
         return self._obj
 
@@ -1503,7 +1501,7 @@ class SeriesChecks:
     def shape(
         self,
         fn: Callable = lambda s: s,
-        check_name: Union[str, None] = "📐 Shape",
+        msg: Union[str, None] = "📐 Shape",
     ) -> pd.Series:
         """Displays the Series's dimensions, without modifying the Series itself.
 
@@ -1513,13 +1511,13 @@ class SeriesChecks:
                 iris
                 ["sepal_width"]
                 .check.shape()
-                .check.shape(fn=lambda s: s[s<5]), check_name="Shape of sepal_width series with values <5")
+                .check.shape(fn=lambda s: s[s<5]), msg="Shape of sepal_width series with values <5")
             )
             ```
 
         Args:
             fn: An optional lambda function to apply to the Series before running Pandas `shape`. Example: `lambda s: s.dropna()`.
-            check_name: An optional name for the check, to be printed as preface to the result.
+            msg: An optional name for the check, to be printed as preface to the result.
 
         Returns:
             The original Series, unchanged.
@@ -1532,7 +1530,7 @@ class SeriesChecks:
             self._obj,
             check_fn=lambda s: s.shape,
             modify_fn=fn,
-            check_name=check_name,
+            msg=msg,
         )
         return self._obj
 
@@ -1540,7 +1538,7 @@ class SeriesChecks:
         self,
         n: int = 5,
         fn: Callable = lambda s: s,
-        check_name: Union[str, None] = None,
+        msg: Union[str, None] = None,
     ) -> pd.Series:
         """Displays the last n rows of the Series, without modifying the Series itself.
 
@@ -1557,21 +1555,21 @@ class SeriesChecks:
         Args:
             n: Number of rows to show.
             fn: An optional lambda function to apply to the Series before running Pandas tail(). Example: `lambda s: s.dropna()`.
-            check_name: An optional name for the check, to be printed as preface to the result.
+            msg: An optional name for the check, to be printed as preface to the result.
 
         Returns:
             The original Series, unchanged.
         """
         (
             pd.DataFrame(_apply_modifications(self._obj, fn))
-            .check.tail(n=n, check_name=check_name)
+            .check.tail(n=n, msg=msg)
         )  # fmt: skip
         return self._obj
 
     def unique(
         self,
         fn: Callable = lambda s: s,
-        check_name: Union[str, None] = None,
+        msg: Union[str, None] = None,
     ) -> pd.Series:
         """Displays the unique values in a Series, without modifying the Series itself.
 
@@ -1589,22 +1587,22 @@ class SeriesChecks:
 
         Args:
             fn: An optional lambda function to apply to the Series before running Pandas unique(). Example: `lambda s: s.dropna()`.
-            check_name: An optional name for the check, to be printed as preface to the result.
+            msg: An optional name for the check, to be printed as preface to the result.
 
         Returns:
             The original Series, unchanged.
         """
-        if not check_name:
+        if not msg:
             if self._obj.name:
-                check_name = f"🌟 Unique values of '{self._obj.name}'"
+                msg = f"🌟 Unique values of '{self._obj.name}'"
             else:
-                check_name = "🌟 Unique values"
+                msg = "🌟 Unique values"
 
         _check_data(
             self._obj,
             check_fn=lambda s: s.unique().tolist(),
             modify_fn=fn,
-            check_name=check_name,
+            msg=msg,
         )
         return self._obj
 
@@ -1612,7 +1610,7 @@ class SeriesChecks:
         self,
         fn: Callable = lambda s: s,
         max_rows: int = 10,
-        check_name: Union[str, None] = None,
+        msg: Union[str, None] = None,
         **kwargs: Any,
     ) -> pd.Series:
         """Displays the value counts for a Series, without modifying the Series itself.
@@ -1631,24 +1629,24 @@ class SeriesChecks:
         Args:
             max_rows: Maximum number of rows to show in the value counts.
             fn: An optional lambda function to apply to the Series before running Pandas value_counts(). Example: `lambda s: s.dropna()`.
-            check_name: An optional name for the check, to be printed as preface to the result.
+            msg: An optional name for the check, to be printed as preface to the result.
             **kwargs: Optional, additional arguments that are accepted by Pandas value_counts() method.
 
         Returns:
             The original Series, unchanged.
         """
-        if not check_name:
+        if not msg:
             if self._obj.name:
-                check_name = f"🧮 Value counts in '{self._obj.name}'"
+                msg = f"🧮 Value counts in '{self._obj.name}'"
             else:
-                check_name = "🧮 Value counts"
+                msg = "🧮 Value counts"
             if max_rows:
-                check_name = check_name + f", first {max_rows} values"
+                msg = msg + f", first {max_rows} values"
         _check_data(
             self._obj,
             check_fn=lambda s: s.value_counts(**kwargs).head(max_rows),
             modify_fn=fn,
-            check_name=check_name,
+            msg=msg,
         )
         return self._obj
 

--- a/pandas_checks/SeriesChecks.py
+++ b/pandas_checks/SeriesChecks.py
@@ -883,7 +883,7 @@ class SeriesChecks:
 
         Args:
             fn: An optional lambda function to apply to the Series before running Pandas describe(). Example: `lambda s: s.dropna()`.
-            msg: An optional name for the check to preface the result with.
+            msg: Optionally customize the text displayed before the result of the check.
             **kwargs: Optional, additional arguments that are accepted by Pandas describe() method.
 
         Returns:
@@ -936,7 +936,7 @@ class SeriesChecks:
 
         Args:
             fn: An optional lambda function to apply to the Series before running Pandas dtype. Example: `lambda s: s.dropna()`.
-            msg: An optional name for the check to preface the result with.
+            msg: Optionally customize the text displayed before the result of the check.
 
         Returns:
             The original Series, unchanged.
@@ -990,7 +990,7 @@ class SeriesChecks:
 
         Args:
             fn: The lambda function to apply to the Series. Example: `lambda s: s.dropna()`.
-            msg: An optional name for the check to preface the result with.
+            msg: Optionally customize the text displayed before the result of the check.
 
         Returns:
             The original Series, unchanged.
@@ -1013,7 +1013,7 @@ class SeriesChecks:
             ```
 
         Args:
-            msg: An optional name for the check. Will be used as a preface the printed result.
+            msg: Optionally customize the text displayed before the result of the check.
 
         Returns:
             The original Series, unchanged.
@@ -1046,7 +1046,7 @@ class SeriesChecks:
         Args:
             n: The number of rows to display.
             fn: An optional lambda function to apply to the Series before running Pandas head(). Example: `lambda s: s.dropna()`.
-            msg: An optional name for the check, to be printed as preface to the result.
+            msg: Optionally customize the text displayed before the result of the check.
 
         Returns:
             The original Series, unchanged.
@@ -1078,7 +1078,7 @@ class SeriesChecks:
 
         Args:
             fn: An optional lambda function to apply to the Series before running Pandas head(). Example: `lambda s: s.dropna()`.
-            msg: An optional name for the check, to be printed as preface to the result.
+            msg: Optionally customize the text displayed before the result of the check.
             **kwargs: Optional, additional arguments that are accepted by Pandas hist() method.
 
         Returns:
@@ -1114,7 +1114,7 @@ class SeriesChecks:
 
         Args:
             fn: An optional lambda function to apply to the Series before running Pandas info(). Example: `lambda s: s.dropna()`.
-            msg: An optional name for the check, to be printed as preface to the result.
+            msg: Optionally customize the text displayed before the result of the check.
             **kwargs: Optional, additional arguments that are accepted by Pandas info() method.
 
         Returns:
@@ -1147,7 +1147,7 @@ class SeriesChecks:
 
         Args:
             fn: An optional lambda function to apply to the Series before running Pandas memory_usage(). Example: `lambda s: s.dropna()`.
-            msg: An optional name for the check, to be printed as preface to the result.
+            msg: Optionally customize the text displayed before the result of the check.
             **kwargs: Optional, additional arguments that are accepted by Pandas memory_usage() method.
 
         Returns:
@@ -1183,7 +1183,7 @@ class SeriesChecks:
 
         Args:
             fn: An optional lambda function to apply to the Series before counting the number of duplicates. Example: `lambda s: s.dropna()`.
-            msg: An optional name for the check, to be printed as preface to the result.
+            msg: Optionally customize the text displayed before the result of the check.
             **kwargs: Optional, additional arguments that are accepted by Pandas duplicated() method.
 
         Returns:
@@ -1215,7 +1215,7 @@ class SeriesChecks:
 
         Args:
             fn: An optional lambda function to apply to the Series before counting rows with nulls. Example: `lambda s: s.dropna()`.
-            msg: An optional name for the check, to be printed as preface to the result.
+            msg: Optionally customize the text displayed before the result of the check.
 
         Returns:
             The original Series, unchanged.
@@ -1244,7 +1244,7 @@ class SeriesChecks:
 
         Args:
             fn: An optional lambda function to apply to the Series before counting the number of rows. Example: `lambda s: s.dropna()`.
-            msg: An optional name for the check, to be printed as preface to the result.
+            msg: Optionally customize the text displayed before the result of the check.
 
         Returns:
             The original Series, unchanged.
@@ -1276,7 +1276,7 @@ class SeriesChecks:
 
         Args:
             fn: An optional lambda function to apply to the Series before running Pandas nunique(). Example: `lambda s: s.dropna()`.
-            msg: An optional name for the check, to be printed as preface to the result.
+            msg: Optionally customize the text displayed before the result of the check.
             **kwargs: Optional, additional arguments that are accepted by Pandas nunique() method.
 
         Returns:
@@ -1361,7 +1361,7 @@ class SeriesChecks:
         Args:
             object: Object to print. Can be anything printable: str, int, list, another DataFrame, etc. If None, print the Series's head (with `max_rows` rows).
             fn: An optional lambda function to apply to the Series before printing `object`. Example: `lambda s: s.dropna()`.
-            msg: An optional name for the check, to be printed as preface to the result.
+            msg: Optionally customize the text displayed before the result of the check.
             max_rows: Maximum number of rows to print if object=None.
 
         Returns:
@@ -1517,7 +1517,7 @@ class SeriesChecks:
 
         Args:
             fn: An optional lambda function to apply to the Series before running Pandas `shape`. Example: `lambda s: s.dropna()`.
-            msg: An optional name for the check, to be printed as preface to the result.
+            msg: Optionally customize the text displayed before the result of the check.
 
         Returns:
             The original Series, unchanged.
@@ -1555,7 +1555,7 @@ class SeriesChecks:
         Args:
             n: Number of rows to show.
             fn: An optional lambda function to apply to the Series before running Pandas tail(). Example: `lambda s: s.dropna()`.
-            msg: An optional name for the check, to be printed as preface to the result.
+            msg: Optionally customize the text displayed before the result of the check.
 
         Returns:
             The original Series, unchanged.
@@ -1587,7 +1587,7 @@ class SeriesChecks:
 
         Args:
             fn: An optional lambda function to apply to the Series before running Pandas unique(). Example: `lambda s: s.dropna()`.
-            msg: An optional name for the check, to be printed as preface to the result.
+            msg: Optionally customize the text displayed before the result of the check.
 
         Returns:
             The original Series, unchanged.
@@ -1629,7 +1629,7 @@ class SeriesChecks:
         Args:
             max_rows: Maximum number of rows to show in the value counts.
             fn: An optional lambda function to apply to the Series before running Pandas value_counts(). Example: `lambda s: s.dropna()`.
-            msg: An optional name for the check, to be printed as preface to the result.
+            msg: Optionally customize the text displayed before the result of the check.
             **kwargs: Optional, additional arguments that are accepted by Pandas value_counts() method.
 
         Returns:

--- a/pandas_checks/SeriesChecks.py
+++ b/pandas_checks/SeriesChecks.py
@@ -1089,7 +1089,7 @@ class SeriesChecks:
         """
         (
             pd.DataFrame(_apply_modifications(self._obj, fn))
-            .check.hist(msg=msg, subset=[], **kwargs)
+            .check.hist(subset=[], msg=msg, **kwargs)
         )  # fmt: skip
         return self._obj
 

--- a/pandas_checks/SeriesChecks.py
+++ b/pandas_checks/SeriesChecks.py
@@ -1191,7 +1191,7 @@ class SeriesChecks:
         """
         (
             pd.DataFrame(_apply_modifications(self._obj, fn))
-            .check.ndups(fn, msg=msg, **kwargs)
+            .check.ndups(fn=fn, msg=msg, **kwargs)
         )  # fmt: skip
         return self._obj
 

--- a/pandas_checks/display.py
+++ b/pandas_checks/display.py
@@ -471,7 +471,7 @@ def _display_check(data: Any, name: Union[str, None] = None) -> None:
     else:
         if isinstance(data, (pd.DataFrame, pd.Series)):
             # Can't display styled tables or use IPython rendering
-            # Print check name and data on separate lines
+            # Print msg and data on separate lines
             _print_router("", bypass_print_fn=True)  # White space
             _print_table(data, title=name)
         else:

--- a/pandas_checks/options.py
+++ b/pandas_checks/options.py
@@ -152,7 +152,7 @@ def _initialize_format_options(options: Union[List[str], None] = None) -> None:
             default_value=True,
             description="""
     : bool
-    Whether Pandas Checks `check_names` text should keep emojis. This includes default check_names from the factory and user-supplied check_names`.
+    Whether Pandas Checks `msg` text should keep emojis. This includes default `msg` from the factory and user-supplied `msg`.
     """,
             validator=cf.is_instance_factory(bool),
         )

--- a/pandas_checks/run_checks.py
+++ b/pandas_checks/run_checks.py
@@ -33,7 +33,7 @@ def _check_data(
     check_fn: Callable = lambda df: df,
     modify_fn: Callable = lambda df: df,
     subset: Union[str, List, None] = None,
-    check_name: Union[str, None] = None,
+    msg: Union[str, None] = None,
 ) -> None:
     """Runs a selected check on a data object
 
@@ -42,7 +42,7 @@ def _check_data(
         check_fn: Function to apply to data for checking. For example if we're running .check.value_counts(), this function would appply the Pandas value_counts() method
         modify_fn: Optional function to modify data _before_ checking
         subset: Optional list of columns or name of column to subset data before running check_fn
-        check_name: Name to use when displaying check result
+        msg: Name to use when displaying check result
 
     Returns:
         None
@@ -58,6 +58,6 @@ def _check_data(
                     # before checking it.
                     _apply_modifications(data, fn=modify_fn, subset=subset)
                 ),
-                name=check_name if check_name else str(subset) if subset else None,
+                name=msg if msg else str(subset) if subset else None,
             )
         )

--- a/tests/cases_dataframechecks.py
+++ b/tests/cases_dataframechecks.py
@@ -126,7 +126,7 @@ def method_assert_unique():
 
 
 def method_columns():
-    return lambda df, _: df.check.columns(fn=lambda df: df.dropna(), msg="Test")
+    return lambda df, _: df.check.columns(msg="Test", fn=lambda df: df.dropna())
 
 
 def method_describe():
@@ -180,7 +180,7 @@ def method_memory_usage():
 
 
 def method_ncols():
-    return lambda df, _: df.check.ncols(fn=lambda df: df.dropna(), msg="Test")
+    return lambda df, _: df.check.ncols(msg="Test", fn=lambda df: df.dropna())
 
 
 def method_ndups():
@@ -196,7 +196,7 @@ def method_nnulls():
 
 
 def method_nrows():
-    return lambda df, _: df.check.nrows(fn=lambda df: df.dropna(), msg="Test")
+    return lambda df, _: df.check.nrows(msg="Test", fn=lambda df: df.dropna())
 
 
 def method_nunique():
@@ -240,7 +240,7 @@ def method_set_mode():
 
 
 def method_shape():
-    return lambda df, _: df.check.shape(fn=lambda df: df.dropna(), msg="Test")
+    return lambda df, _: df.check.shape(msg="Test", fn=lambda df: df.dropna())
 
 
 def method_tail():

--- a/tests/cases_dataframechecks.py
+++ b/tests/cases_dataframechecks.py
@@ -126,11 +126,11 @@ def method_assert_unique():
 
 
 def method_columns():
-    return lambda df, _: df.check.columns(fn=lambda df: df.dropna(), check_name="Test")
+    return lambda df, _: df.check.columns(fn=lambda df: df.dropna(), msg="Test")
 
 
 def method_describe():
-    return lambda df, _: df.check.describe(fn=lambda df: df.dropna(), check_name="Test")
+    return lambda df, _: df.check.describe(fn=lambda df: df.dropna(), msg="Test")
 
 
 def method_disable_checks():
@@ -138,7 +138,7 @@ def method_disable_checks():
 
 
 def method_dtypes():
-    return lambda df, _: df.check.dtypes(fn=lambda df: df.dropna(), check_name="Test")
+    return lambda df, _: df.check.dtypes(fn=lambda df: df.dropna(), msg="Test")
 
 
 def method_enable_checks():
@@ -146,31 +146,27 @@ def method_enable_checks():
 
 
 def method_function():
-    return lambda df, _: df.check.function(
-        lambda df: df.assign(new_col=4), check_name="Test"
-    )
+    return lambda df, _: df.check.function(lambda df: df.assign(new_col=4), msg="Test")
 
 
 def method_get_mode():
-    return lambda df, _: df.check.get_mode(check_name="Test")
+    return lambda df, _: df.check.get_mode(msg="Test")
 
 
 def method_head():
-    return lambda df, _: df.check.head(
-        n=10, fn=lambda df: df.dropna(), check_name="Test"
-    )
+    return lambda df, _: df.check.head(n=10, fn=lambda df: df.dropna(), msg="Test")
 
 
 def method_hist():
     return lambda df, _: df.check.hist(
-        fn=lambda df: df.dropna(), check_name="Test", grid=False, bins=100, legend=True
+        fn=lambda df: df.dropna(), msg="Test", grid=False, bins=100, legend=True
     )
 
 
 def method_info():
     return lambda df, _: df.check.info(
         fn=lambda df: df.dropna(),
-        check_name="Test",
+        msg="Test",
         verbose=True,
         max_cols=1,
         show_counts=False,
@@ -179,35 +175,35 @@ def method_info():
 
 def method_memory_usage():
     return lambda df, _: df.check.memory_usage(
-        fn=lambda df: df.dropna(), check_name="Test", index=False, deep=True
+        fn=lambda df: df.dropna(), msg="Test", index=False, deep=True
     )
 
 
 def method_ncols():
-    return lambda df, _: df.check.ncols(fn=lambda df: df.dropna(), check_name="Test")
+    return lambda df, _: df.check.ncols(fn=lambda df: df.dropna(), msg="Test")
 
 
 def method_ndups():
     return lambda df, _: df.check.ndups(
-        fn=lambda df: df.dropna(), check_name="Test", keep=False
+        fn=lambda df: df.dropna(), msg="Test", keep=False
     )
 
 
 def method_nnulls():
     return lambda df, _: df.check.nnulls(
-        fn=lambda df: df.dropna(), by_column=False, check_name="Test"
+        fn=lambda df: df.dropna(), by_column=False, msg="Test"
     )
 
 
 def method_nrows():
-    return lambda df, _: df.check.nrows(fn=lambda df: df.dropna(), check_name="Test")
+    return lambda df, _: df.check.nrows(fn=lambda df: df.dropna(), msg="Test")
 
 
 def method_nunique():
     return lambda df, args: df.check.nunique(
         subset=args["first_num_col"],
         fn=lambda df: df.dropna(),
-        check_name="Test",
+        msg="Test",
         dropna=False,
     )
 
@@ -215,14 +211,14 @@ def method_nunique():
 def method_plot():
     return lambda df, _: df.check.plot(
         fn=lambda df: df.dropna(),
-        check_name="Test",
+        msg="Test",
         subplots=True,
         title="Override",
     )
 
 
 def method_print():
-    return lambda df, _: df.check.print(fn=lambda df: df.dropna(), check_name="Test")
+    return lambda df, _: df.check.print(fn=lambda df: df.dropna(), msg="Test")
 
 
 def method_print_time_elapsed():
@@ -244,18 +240,16 @@ def method_set_mode():
 
 
 def method_shape():
-    return lambda df, _: df.check.shape(fn=lambda df: df.dropna(), check_name="Test")
+    return lambda df, _: df.check.shape(fn=lambda df: df.dropna(), msg="Test")
 
 
 def method_tail():
-    return lambda df, _: df.check.tail(
-        n=20, fn=lambda df: df.dropna(), check_name="Test"
-    )
+    return lambda df, _: df.check.tail(n=20, fn=lambda df: df.dropna(), msg="Test")
 
 
 def method_unique():
     return lambda df, args: df.check.unique(
-        column=args["first_num_col"], fn=lambda df: df.dropna(), check_name="Test"
+        column=args["first_num_col"], fn=lambda df: df.dropna(), msg="Test"
     )
 
 
@@ -264,7 +258,7 @@ def method_value_counts():
         column=args["first_num_col"],
         max_rows=3,
         fn=lambda df: df.dropna(),
-        check_name="Test",
+        msg="Test",
         dropna=False,
         normalize=True,
     )

--- a/tests/cases_serieschecks.py
+++ b/tests/cases_serieschecks.py
@@ -162,7 +162,7 @@ def method_assert_unique():
 
 def method_describe():
     return (
-        lambda s, _: s.check.describe(fn=lambda s: s.dropna(), check_name="Test"),
+        lambda s, _: s.check.describe(fn=lambda s: s.dropna(), msg="Test"),
         False,
     )
 
@@ -172,7 +172,7 @@ def method_disable_checks():
 
 
 def method_dtype():
-    return lambda s, _: s.check.dtype(fn=lambda s: s.dropna(), check_name="Test"), False
+    return lambda s, _: s.check.dtype(fn=lambda s: s.dropna(), msg="Test"), False
 
 
 def method_enable_checks():
@@ -181,18 +181,18 @@ def method_enable_checks():
 
 def method_function():
     return (
-        lambda s, _: s.check.function(lambda s: s.shape[0] * 2, check_name="Test"),
+        lambda s, _: s.check.function(lambda s: s.shape[0] * 2, msg="Test"),
         False,
     )
 
 
 def method_get_mode():
-    return lambda s, _: s.check.get_mode(check_name="Test"), False
+    return lambda s, _: s.check.get_mode(msg="Test"), False
 
 
 def method_head():
     return (
-        lambda s, _: s.check.head(n=7, fn=lambda s: s.dropna(), check_name="Test"),
+        lambda s, _: s.check.head(n=7, fn=lambda s: s.dropna(), msg="Test"),
         False,
     )
 
@@ -200,7 +200,7 @@ def method_head():
 def method_hist():
     return (
         lambda s, _: s.check.hist(
-            fn=lambda s: s.dropna(), check_name="Test", grid=True, bins=5, legend=False
+            fn=lambda s: s.dropna(), msg="Test", grid=True, bins=5, legend=False
         ),
         False,
     )
@@ -210,7 +210,7 @@ def method_info():
     return (
         lambda s, _: s.check.info(
             fn=lambda s: s.dropna(),
-            check_name="Test",
+            msg="Test",
             verbose=True,
             show_counts=True,
         ),
@@ -221,7 +221,7 @@ def method_info():
 def method_memory_usage():
     return (
         lambda s, _: s.check.memory_usage(
-            fn=lambda s: s.dropna(), check_name="Test", index=True, deep=True
+            fn=lambda s: s.dropna(), msg="Test", index=True, deep=True
         ),
         False,
     )
@@ -229,29 +229,25 @@ def method_memory_usage():
 
 def method_ndups():
     return (
-        lambda s, _: s.check.ndups(
-            fn=lambda s: s.dropna(), check_name="Test", keep="last"
-        ),
+        lambda s, _: s.check.ndups(fn=lambda s: s.dropna(), msg="Test", keep="last"),
         False,
     )
 
 
 def method_nnulls():
     return (
-        lambda s, _: s.check.nnulls(fn=lambda s: s.dropna(), check_name="Test"),
+        lambda s, _: s.check.nnulls(fn=lambda s: s.dropna(), msg="Test"),
         False,
     )
 
 
 def method_nrows():
-    return lambda s, _: s.check.nrows(fn=lambda s: s.dropna(), check_name="Test"), False
+    return lambda s, _: s.check.nrows(fn=lambda s: s.dropna(), msg="Test"), False
 
 
 def method_nunique():
     return (
-        lambda s, _: s.check.nunique(
-            fn=lambda s: s.dropna(), check_name="Test", dropna=False
-        ),
+        lambda s, _: s.check.nunique(fn=lambda s: s.dropna(), msg="Test", dropna=False),
         False,
     )
 
@@ -260,7 +256,7 @@ def method_plot():
     return (
         lambda s, _: s.check.plot(
             fn=lambda s: s.dropna(),
-            check_name="Test",
+            msg="Test",
             title="Override",
         ),
         False,
@@ -268,7 +264,7 @@ def method_plot():
 
 
 def method_print():
-    return lambda s, _: s.check.print(fn=lambda s: s.dropna(), check_name="Test"), False
+    return lambda s, _: s.check.print(fn=lambda s: s.dropna(), msg="Test"), False
 
 
 def method_print_time_elapsed():
@@ -296,16 +292,16 @@ def method_set_mode():
 
 
 def method_shape():
-    return lambda s, _: s.check.shape(fn=lambda s: s.dropna(), check_name="Test"), False
+    return lambda s, _: s.check.shape(fn=lambda s: s.dropna(), msg="Test"), False
 
 
 def method_tail():
-    return lambda s, _: s.check.tail(fn=lambda s: s.dropna(), check_name="Test"), False
+    return lambda s, _: s.check.tail(fn=lambda s: s.dropna(), msg="Test"), False
 
 
 def method_unique():
     return (
-        lambda s, _: s.check.unique(fn=lambda s: s.dropna(), check_name="Test"),
+        lambda s, _: s.check.unique(fn=lambda s: s.dropna(), msg="Test"),
         False,
     )
 
@@ -313,7 +309,7 @@ def method_unique():
 def method_value_counts():
     return (
         lambda s, _: s.check.value_counts(
-            fn=lambda s: s.dropna(), check_name="Test", dropna=False, normalize=True
+            fn=lambda s: s.dropna(), msg="Test", dropna=False, normalize=True
         ),
         False,
     )

--- a/tests/cases_serieschecks.py
+++ b/tests/cases_serieschecks.py
@@ -242,7 +242,7 @@ def method_nnulls():
 
 
 def method_nrows():
-    return lambda s, _: s.check.nrows(fn=lambda s: s.dropna(), msg="Test"), False
+    return lambda s, _: s.check.nrows(msg="Test", fn=lambda s: s.dropna()), False
 
 
 def method_nunique():
@@ -292,7 +292,7 @@ def method_set_mode():
 
 
 def method_shape():
-    return lambda s, _: s.check.shape(fn=lambda s: s.dropna(), msg="Test"), False
+    return lambda s, _: s.check.shape(msg="Test", fn=lambda s: s.dropna()), False
 
 
 def method_tail():

--- a/tests/test_dataframechecks.py
+++ b/tests/test_dataframechecks.py
@@ -167,16 +167,16 @@ def test_DataFrameChecks_ncols(iris, capsys):
 
 
 def test_DataFrameChecks_ndups(iris, capsys):
-    iris.check.ndups(fn=lambda df: df.assign(C=55), msg="Test", subset=["C", "species"])
+    iris.check.ndups(subset=["C", "species"], fn=lambda df: df.assign(C=55), msg="Test")
     assert capsys.readouterr().out == "\nTest: 147\n"
 
 
 def test_DataFrameChecks_ndups_keep(iris, capsys):
     """Test that a kwarg is getting passed to Pandas's memory_usage()"""
     iris.check.ndups(
+        subset=["C", "species"],
         fn=lambda df: df.assign(C=55),
         msg="Test",
-        subset=["C", "species"],
         keep=False,
     )
     assert capsys.readouterr().out == "\nTest: 150\n"

--- a/tests/test_dataframechecks.py
+++ b/tests/test_dataframechecks.py
@@ -47,7 +47,7 @@ def test_DataFrameChecks_describe(iris, capsys):
     iris.check.describe(
         fn=lambda df: (df * 2),
         subset=["petal_width", "species"],
-        check_name="Test",
+        msg="Test",
         include="all",
     )
     assert (
@@ -87,17 +87,17 @@ def test_DataFrameChecks_dtypes(iris, capsys):
 
 
 def test_DataFrameChecks_function_with_lambda_fn(iris, capsys):
-    iris.check.function(fn=lambda df: len(df.columns), check_name="Test")
+    iris.check.function(fn=lambda df: len(df.columns), msg="Test")
     assert capsys.readouterr().out == """\nTest: 5\n"""
 
 
 def test_DataFrameChecks_function_with_str_fn(iris, capsys):
-    iris.check.function(fn=lambda df: len(df.columns), check_name="Test")
+    iris.check.function(fn=lambda df: len(df.columns), msg="Test")
     assert capsys.readouterr().out == """\nTest: 5\n"""
 
 
 def test_DataFrameChecks_get_mode(iris, capsys):
-    iris.check.get_mode(check_name="Test")
+    iris.check.get_mode(msg="Test")
     assert (
         capsys.readouterr().out
         == """\nTest: {'enable_checks': True, 'enable_asserts': True}\n"""
@@ -105,7 +105,7 @@ def test_DataFrameChecks_get_mode(iris, capsys):
 
 
 def test_DataFrameChecks_head(iris, capsys):
-    iris.check.head(n=1, fn=lambda df: (df * 2), check_name="Test")
+    iris.check.head(n=1, fn=lambda df: (df * 2), msg="Test")
     assert (
         capsys.readouterr().out
         == """\nTest
@@ -123,7 +123,7 @@ def test_DataFrameChecks_info(iris, capsys):
     iris.check.info(
         fn=lambda df: (df * 2),
         subset=["petal_width", "species"],
-        check_name="Test",
+        msg="Test",
         memory_usage=True,
     )
     assert (
@@ -145,7 +145,7 @@ def test_DataFrameChecks_info(iris, capsys):
 def test_DataFrameChecks_memory_usage(iris, capsys):
     iris.check.memory_usage(
         fn=lambda df: df[["petal_width", "species"]].dropna(),
-        check_name="Test",
+        msg="Test",
         deep=False,
         index=False,  # Avoids inconsistency where index size is different in Python 3.11 only
     )
@@ -162,16 +162,12 @@ def test_DataFrameChecks_memory_usage(iris, capsys):
 
 
 def test_DataFrameChecks_ncols(iris, capsys):
-    iris.check.ncols(
-        fn=lambda df: df.assign(C=55), check_name="Test", subset=["C", "species"]
-    )
+    iris.check.ncols(fn=lambda df: df.assign(C=55), msg="Test", subset=["C", "species"])
     assert capsys.readouterr().out == "\nTest: 2\n"
 
 
 def test_DataFrameChecks_ndups(iris, capsys):
-    iris.check.ndups(
-        fn=lambda df: df.assign(C=55), check_name="Test", subset=["C", "species"]
-    )
+    iris.check.ndups(fn=lambda df: df.assign(C=55), msg="Test", subset=["C", "species"])
     assert capsys.readouterr().out == "\nTest: 147\n"
 
 
@@ -179,7 +175,7 @@ def test_DataFrameChecks_ndups_keep(iris, capsys):
     """Test that a kwarg is getting passed to Pandas's memory_usage()"""
     iris.check.ndups(
         fn=lambda df: df.assign(C=55),
-        check_name="Test",
+        msg="Test",
         subset=["C", "species"],
         keep=False,
     )
@@ -187,37 +183,29 @@ def test_DataFrameChecks_ndups_keep(iris, capsys):
 
 
 def test_DataFrameChecks_nnulls(iris, capsys):
-    iris.check.nnulls(
-        fn=lambda df: df.assign(C=np.nan), check_name="Test", by_column=False
-    )
+    iris.check.nnulls(fn=lambda df: df.assign(C=np.nan), msg="Test", by_column=False)
     assert capsys.readouterr().out == "\nTest: 150\n"
 
 
 def test_DataFrameChecks_nrows(iris, capsys):
-    iris.check.nrows(
-        fn=lambda df: df.assign(C=55), check_name="Test", subset=["C", "species"]
-    )
+    iris.check.nrows(fn=lambda df: df.assign(C=55), msg="Test", subset=["C", "species"])
     assert capsys.readouterr().out == "\nTest: 150\n"
 
 
 def test_DataFrameChecks_nunique_one_column(iris, capsys):
-    iris.check.nunique(
-        fn=lambda df: df, check_name="Test", column="species", dropna=False
-    )
+    iris.check.nunique(fn=lambda df: df, msg="Test", column="species", dropna=False)
     assert capsys.readouterr().out == "\nTest: 3\n"
 
 
 def test_DataFrameChecks_nunique_subset_one_column(iris, capsys):
-    iris.check.nunique(
-        fn=lambda df: df, check_name="Test", subset="species", dropna=False
-    )
+    iris.check.nunique(fn=lambda df: df, msg="Test", subset="species", dropna=False)
     assert capsys.readouterr().out == "\nTest: 3\n"
 
 
 def test_DataFrameChecks_nunique_across_columns(iris, capsys):
     iris.check.nunique(
         fn=lambda df: df.assign(C=55),
-        check_name="Test",
+        msg="Test",
         subset=["species", "petal_width"],
         across_columns=True,
     )
@@ -244,7 +232,7 @@ def test_DataFrameChecks_print_df(iris, capsys):
             "petal_width",
             "species",
         ],
-        check_name="Test",
+        msg="Test",
         max_rows=1,
     )
     assert (
@@ -290,7 +278,7 @@ def test_DataFrameChecks_reset_format(iris, capsys):
                 "petal_width",
                 "species",
             ],
-            check_name="🧦 Sock",
+            msg="🧦 Sock",
             max_rows=1,
         )
     )
@@ -314,7 +302,7 @@ def test_DataFrameChecks_set_format(iris, capsys):
                 "petal_width",
                 "species",
             ],
-            check_name="🧦 Sock",
+            msg="🧦 Sock",
             max_rows=1,
         )
         .check.reset_format()
@@ -338,14 +326,12 @@ def test_DataFrameChecks_set_mode(iris, capsys):
 
 
 def test_DataFrameChecks_shape(iris, capsys):
-    iris.check.shape(
-        fn=lambda df: df.assign(C=55), check_name="Test", subset=["C", "species"]
-    )
+    iris.check.shape(fn=lambda df: df.assign(C=55), msg="Test", subset=["C", "species"])
     assert capsys.readouterr().out == "\nTest: (150, 2)\n"
 
 
 def test_DataFrameChecks_tail(iris, capsys):
-    iris.check.tail(n=1, fn=lambda df: (df * 2), check_name="Test")
+    iris.check.tail(n=1, fn=lambda df: (df * 2), msg="Test")
     assert (
         capsys.readouterr().out
         == """\nTest
@@ -358,7 +344,7 @@ def test_DataFrameChecks_unique(iris, capsys):
     iris.check.unique(
         column="species",
         fn=lambda df: df.assign(species_upper=df.species.str.upper()),
-        check_name="🛼 Unique",
+        msg="🛼 Unique",
     )
     assert (
         capsys.readouterr().out == "\n🛼 Unique: ['setosa', 'versicolor', 'virginica']\n"
@@ -370,7 +356,7 @@ def test_DataFrameChecks_value_counts(iris, capsys):
     iris.check.value_counts(
         column="species",
         fn=lambda df: df.replace("setosa", None),
-        check_name="Test",
+        msg="Test",
         dropna=False,
         normalize=True,
     )

--- a/tests/test_dataframechecks.py
+++ b/tests/test_dataframechecks.py
@@ -162,7 +162,7 @@ def test_DataFrameChecks_memory_usage(iris, capsys):
 
 
 def test_DataFrameChecks_ncols(iris, capsys):
-    iris.check.ncols(fn=lambda df: df.assign(C=55), msg="Test", subset=["C", "species"])
+    iris.check.ncols(msg="Test", fn=lambda df: df.assign(C=55), subset=["C", "species"])
     assert capsys.readouterr().out == "\nTest: 2\n"
 
 
@@ -188,7 +188,7 @@ def test_DataFrameChecks_nnulls(iris, capsys):
 
 
 def test_DataFrameChecks_nrows(iris, capsys):
-    iris.check.nrows(fn=lambda df: df.assign(C=55), msg="Test", subset=["C", "species"])
+    iris.check.nrows(msg="Test", fn=lambda df: df.assign(C=55), subset=["C", "species"])
     assert capsys.readouterr().out == "\nTest: 150\n"
 
 
@@ -326,7 +326,7 @@ def test_DataFrameChecks_set_mode(iris, capsys):
 
 
 def test_DataFrameChecks_shape(iris, capsys):
-    iris.check.shape(fn=lambda df: df.assign(C=55), msg="Test", subset=["C", "species"])
+    iris.check.shape(msg="Test", fn=lambda df: df.assign(C=55), subset=["C", "species"])
     assert capsys.readouterr().out == "\nTest: (150, 2)\n"
 
 

--- a/tests/test_run_checks.py
+++ b/tests/test_run_checks.py
@@ -42,9 +42,9 @@ def test_check_data_enable_checks(capsys):
     check_fn = lambda x: x.dtypes
     modify_fn = lambda x: x
     subset = None
-    check_name = "Test Check"
+    msg = "Test Check"
     pdc.enable_checks()
-    _check_data(df, check_fn, modify_fn, subset, check_name)
+    _check_data(df, check_fn, modify_fn, subset, msg)
     assert "Test Check" in capsys.readouterr().out  # Partial check
 
 
@@ -53,8 +53,8 @@ def test_check_data_disable_checks(capsys):
     check_fn = lambda x: x.dtypes
     modify_fn = lambda x: x
     subset = None
-    check_name = "Test Check"
+    msg = "Test Check"
     pdc.disable_checks()
-    _check_data(df, check_fn, modify_fn, subset, check_name)
+    _check_data(df, check_fn, modify_fn, subset, msg)
     assert capsys.readouterr().out == ""
     pdc.enable_checks()  # Reset

--- a/tests/test_serieschecks.py
+++ b/tests/test_serieschecks.py
@@ -208,7 +208,7 @@ def test_SeriesChecks_nnulls(iris, capsys):
 
 
 def test_SeriesChecks_nrows(iris, capsys):
-    iris["species"].check.nrows(fn=lambda s: s[s == "versicolor"], msg="Test")
+    iris["species"].check.nrows(msg="Test", fn=lambda s: s[s == "versicolor"])
     assert capsys.readouterr().out == "\nTest: 50\n"
 
 
@@ -320,7 +320,7 @@ def test_SeriesChecks_set_mode(iris, capsys):
 
 def test_SeriesChecks_shape(iris, capsys):
     iris["sepal_width"].check.shape(
-        fn=lambda s: pd.concat([s, s], ignore_index=True, axis=0), msg="Test"
+        msg="Test", fn=lambda s: pd.concat([s, s], ignore_index=True, axis=0)
     )
     assert capsys.readouterr().out == "\nTest: (300,)\n"
 

--- a/tests/test_serieschecks.py
+++ b/tests/test_serieschecks.py
@@ -75,7 +75,7 @@ def test_SeriesChecks_describe(iris, capsys):
     (
         iris["petal_width"].check.describe(
             fn=lambda s: (s * 2),
-            check_name="Test",
+            msg="Test",
             include="all",
         )
     )
@@ -111,12 +111,12 @@ def test_SeriesChecks_dtype(iris, capsys):
 
 
 def test_SeriesChecks_function(iris, capsys):
-    iris["species"].check.function(fn=lambda s: s.shape[0], check_name="Test")
+    iris["species"].check.function(fn=lambda s: s.shape[0], msg="Test")
     assert capsys.readouterr().out == """\nTest: 150\n"""
 
 
 def test_SeriesChecks_get_mode(iris, capsys):
-    iris.check.get_mode(check_name="Test")
+    iris.check.get_mode(msg="Test")
     assert (
         capsys.readouterr().out
         == """\nTest: {'enable_checks': True, 'enable_asserts': True}\n"""
@@ -124,7 +124,7 @@ def test_SeriesChecks_get_mode(iris, capsys):
 
 
 def test_SeriesChecks_head(iris, capsys):
-    iris["sepal_length"].check.head(n=1, fn=lambda s: (s * 2), check_name="Test")
+    iris["sepal_length"].check.head(n=1, fn=lambda s: (s * 2), msg="Test")
     assert_multiline_string_equal(
         capsys.readouterr().out,
         """\nTest
@@ -141,7 +141,7 @@ def test_SeriesChecks_hist_no_terminal_display(iris, capsys):
 def test_SeriesChecks_info(iris, capsys):
     iris["petal_width"].check.info(
         fn=lambda s: (s * 2),
-        check_name="Test",
+        msg="Test",
         memory_usage=True,
     )
     assert_multiline_string_equal(
@@ -174,7 +174,7 @@ memory usage: 1.3 KB
 def test_SeriesChecks_memory_usage(iris, capsys):
     (
         iris["petal_width"].check.memory_usage(
-            fn=lambda s: s.dropna(), check_name="Test", deep=False, index=False
+            fn=lambda s: s.dropna(), msg="Test", deep=False, index=False
         )
     )
     assert_multiline_string_equal(
@@ -185,7 +185,7 @@ def test_SeriesChecks_memory_usage(iris, capsys):
 
 
 def test_SeriesChecks_ndups(iris, capsys):
-    iris["species"].check.ndups(fn=lambda s: s.dropna(), check_name="Test")
+    iris["species"].check.ndups(fn=lambda s: s.dropna(), msg="Test")
     assert capsys.readouterr().out == "\nTest: 147\n"
 
 
@@ -193,7 +193,7 @@ def test_SeriesChecks_ndups_keep(iris, capsys):
     """Test that a kwarg is getting passed to Pandas's memory_usage()"""
     iris["species"].check.ndups(
         fn=lambda s: s.dropna(),
-        check_name="Test",
+        msg="Test",
         keep=False,
     )
     assert capsys.readouterr().out == "\nTest: 150\n"
@@ -202,19 +202,19 @@ def test_SeriesChecks_ndups_keep(iris, capsys):
 def test_SeriesChecks_nnulls(iris, capsys):
     iris["species"].check.nnulls(
         fn=lambda s: s.replace("versicolor", np.nan),
-        check_name="Test",
+        msg="Test",
     )
     assert capsys.readouterr().out == "\nTest: 50\n"
 
 
 def test_SeriesChecks_nrows(iris, capsys):
-    iris["species"].check.nrows(fn=lambda s: s[s == "versicolor"], check_name="Test")
+    iris["species"].check.nrows(fn=lambda s: s[s == "versicolor"], msg="Test")
     assert capsys.readouterr().out == "\nTest: 50\n"
 
 
 def test_SeriesChecks_nunique(iris, capsys):
     iris["species"].check.nunique(
-        fn=lambda s: s[s != "versicolor"], check_name="Test", dropna=False
+        fn=lambda s: s[s != "versicolor"], msg="Test", dropna=False
     )
     assert capsys.readouterr().out == "\nTest: 2\n"
 
@@ -232,7 +232,7 @@ def test_SeriesChecks_print_str(iris, capsys):
 def test_SeriesChecks_print_series(iris, capsys):
     iris["sepal_length"].check.print(
         fn=lambda s: s * 2,
-        check_name="Test",
+        msg="Test",
         max_rows=1,
     )
     assert_multiline_string_equal(
@@ -276,7 +276,7 @@ def test_SeriesChecks_reset_format(iris, capsys):
         .check.reset_format()
         .check.print(
             fn=lambda s: s * 2,
-            check_name="🧦 Sock",
+            msg="🧦 Sock",
             max_rows=1,
         )
     )
@@ -294,7 +294,7 @@ def test_SeriesChecks_set_format(iris, capsys):
         .check.set_format(precision=10, use_emojis=False)
         .check.print(
             fn=lambda s: s * 2,
-            check_name="🧦 Sock",
+            msg="🧦 Sock",
             max_rows=1,
         )
         .check.reset_format()
@@ -320,13 +320,13 @@ def test_SeriesChecks_set_mode(iris, capsys):
 
 def test_SeriesChecks_shape(iris, capsys):
     iris["sepal_width"].check.shape(
-        fn=lambda s: pd.concat([s, s], ignore_index=True, axis=0), check_name="Test"
+        fn=lambda s: pd.concat([s, s], ignore_index=True, axis=0), msg="Test"
     )
     assert capsys.readouterr().out == "\nTest: (300,)\n"
 
 
 def test_SeriesChecks_tail(iris, capsys):
-    (iris["sepal_length"].check.tail(n=1, fn=lambda s: s * 2, check_name="Test"))
+    (iris["sepal_length"].check.tail(n=1, fn=lambda s: s * 2, msg="Test"))
     assert_multiline_string_equal(
         capsys.readouterr().out,
         """\nTest
@@ -338,7 +338,7 @@ def test_SeriesChecks_tail(iris, capsys):
 def test_SeriesChecks_unique(iris, capsys):
     iris["species"].check.unique(
         fn=lambda s: s.str.upper(),
-        check_name="🛼 Unique",
+        msg="🛼 Unique",
     )
     assert (
         capsys.readouterr().out == "\n🛼 Unique: ['SETOSA', 'VERSICOLOR', 'VIRGINICA']\n"
@@ -349,7 +349,7 @@ def test_SeriesChecks_value_counts(iris, capsys):
     """Test that kwargs are getting passed to Pandas's value_counts()"""
     iris["species"].check.value_counts(
         fn=lambda s: s.replace("setosa", None),
-        check_name="Test",
+        msg="Test",
         dropna=False,
         normalize=True,
     )


### PR DESCRIPTION
Partially addresses #59 

1. Renames `check_name` to `msg` everywhere
2. Moves `msg` to the first argument on these methods, where it makes intuitive sense:
 - check.columns
 - check.shape
 - check.ncols
 - check.nrows

Pull request checklist
- [X] PR describes the changes proposed
- [X] Tests were checked for updates
- [X] Tests pass with `nox`
- [X] Docstrings and docs were checked for updates
