### PR TITLE
Fix bug in `check.nunique()`

### DIFF
--- a/pandas_checks/DataFrameChecks.py
+++ b/pandas_checks/DataFrameChecks.py
@@ -1541,7 +1541,6 @@ class DataFrameChecks:
                 _check_data(
                     data_modified,
                     check_fn=lambda data: data.nunique(**kwargs),
-                    modify_fn=fn,
                     msg=msg,
                 )  # fmt: skip
             else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pandas-checks"
-version = "2.0.0"
+version = "2.0.1"
 description = "Non-invasive health checks for Pandas method chains"
 authors = [{name = "Chad Parmet", email= "cparmet@gmail.com"}]
 readme = "README.md"

--- a/tests/test_dataframechecks.py
+++ b/tests/test_dataframechecks.py
@@ -212,6 +212,17 @@ def test_DataFrameChecks_nunique_across_columns(iris, capsys):
     assert capsys.readouterr().out == "\nTest: 27\n"
 
 
+def test_DataFrameChecks_nunique_select_cols_first(iris, capsys):
+    # Issue #72
+    iris.check.nunique(
+        subset="species",
+        fn=lambda df: df.loc[df["petal_length"] == 1.4],
+        dropna=False,
+        msg="Test",
+    )
+    assert capsys.readouterr().out == "\nTest: 1\n"
+
+
 def test_DataFrameChecks_plot_no_terminal_display(iris, capsys):
     iris.check.plot(subset=["sepal_width", "petal_length"])
     assert capsys.readouterr().out == ""

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-13T20:34:51.08948Z"
+exclude-newer = "2026-05-18T11:56:55.889834Z"
 exclude-newer-span = "P14D"
 
 [[package]]
@@ -1709,7 +1709,7 @@ wheels = [
 
 [[package]]
 name = "pandas-checks"
-version = "2.0.0"
+version = "2.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "emoji" },


### PR DESCRIPTION
Fixes bug introduced by #67, which led `.check.nunique()` to apply `fn` twice. 

Addresses #72 .

New result of running the cases in that Issue
```python
df = pd.DataFrame({"A":["one","two","one","two","three"], "B":[1,1,0,0,0]})

df.check.nunique("A", fn = lambda x: x.loc[pd.col("B") > 0])
# 🌟 Unique values in A: 2

df.check.nunique("A", fn = lambda x: x.loc[lambda y: y["B"] > 0])
# 🌟 Unique values in A: 2
```

Pull request checklist
- [x] PR describes the changes proposed
- [x] Tests were checked for updates
- [x] Tests pass with `nox`
- [x] Docstrings and docs were checked for updates
